### PR TITLE
Prevents XSS injection when browsing table

### DIFF
--- a/config.inc.php-dist
+++ b/config.inc.php-dist
@@ -7,6 +7,10 @@
 	 * $Id: config.inc.php-dist,v 1.55 2008/02/18 21:10:31 xzilla Exp $
 	 */
 
+	// Set this to true to enable debug features
+	$conf['debugmode']=false;
+
+
 	// An example server.  Create as many of these as you wish,
 	// indexed from zero upwards.
 

--- a/src/classes/Misc.php
+++ b/src/classes/Misc.php
@@ -11,2253 +11,2204 @@ use \PHPPgAdmin\Decorators\Decorator;
  * $Id: Misc.php,v 1.171 2008/03/17 21:35:48 ioguix Exp $
  */
 
-class Misc {
-
-	use \PHPPgAdmin\HelperTrait;
-
-	private $_connection = null;
-	private $_no_db_connection = false;
-	private $_reload_drop_database = false;
-	private $_reload_browser = false;
-	private $_no_bottom_link = false;
-	private $app = null;
-	private $data = null;
-	private $database = null;
-	private $server_id = null;
-	public $appLangFiles = [];
-	public $appName = '';
-	public $appVersion = '';
-	public $form = '';
-	public $href = '';
-	public $_name = 'Misc';
-	public $lang = [];
-	private $server_info = null;
-	private $_no_output = false;
-	private $container = null;
-
-	/* Constructor */
-	function __construct(\Slim\Container $container) {
-
-		$this->container = $container;
-
-		$this->lang = $container->get('lang');
-		$this->conf = $container->get('conf');
-		$this->view = $container->get('view');
-		$this->plugin_manager = $container->get('plugin_manager');
-		$this->appLangFiles = $container->get('appLangFiles');
-
-		$this->appName = $container->get('settings')['appName'];
-		$this->appVersion = $container->get('settings')['appVersion'];
-		$this->postgresqlMinVer = $container->get('settings')['postgresqlMinVer'];
-		$this->phpMinVer = $container->get('settings')['phpMinVer'];
-
-		$base_version = $container->get('settings')['base_version'];
-		// Check for config file version mismatch
-		if (!isset($this->conf['version']) || $base_version > $this->conf['version']) {
-			die($this->lang['strbadconfig']);
-
-		}
-
-		// Check database support is properly compiled in
-		if (!function_exists('pg_connect')) {
-			die($this->lang['strnotloaded']);
-
-		}
-
-		// Check the version of PHP
-		if (version_compare(phpversion(), $this->phpMinVer, '<')) {
-			exit(sprintf('Version of PHP not supported. Please upgrade to version %s or later.', $this->phpMinVer));
-		}
-
-		if (count($this->conf['servers']) === 1) {
-			$info = $this->conf['servers'][0];
-			$this->server_id = $info['host'] . ':' . $info['port'] . ':' . $info['sslmode'];
-		} else if (isset($_REQUEST['server'])) {
-			$this->server_id = $_REQUEST['server'];
-		} else if (isset($_SESSION['webdbLogin']) && count($_SESSION['webdbLogin']) > 0) {
-			$this->server_id = array_keys($_SESSION['webdbLogin'])[0];
-		}
-	}
-
-	/**
-	 * Default Error Handler. This will be called with the following params
-	 *
-	 * @param $dbms		the RDBMS you are connecting to
-	 * @param $fn		the name of the calling function (in uppercase)
-	 * @param $errno		the native error number from the database
-	 * @param $errmsg	the native error msg from the database
-	 * @param $p1		$fn specific parameter - see below
-	 * @param $P2		$fn specific parameter - see below
-	 */
-	public static function adodb_throw($dbms, $fn, $errno, $errmsg, $p1, $p2, $thisConnection) {
-
-		if (error_reporting() == 0) {
-			return;
-		}
-
-		$backtrace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 2);
-
-		$btarray0 = ([
-			'class' => $backtrace[1]['class'],
-			'type' => $backtrace[1]['type'],
-			'function' => $backtrace[1]['function'],
-			'spacer' => ' ',
-			'line' => $backtrace[0]['line'],
-		]);
-
-		switch ($fn) {
-		case 'EXECUTE':
-			$sql = $p1;
-			$inputparams = $p2;
-
-			/*$s = "<p><b>{$lang['strsqlerror']}</b><br />" . $misc->printVal($errmsg, 'errormsg') . "</p> <p><b>{$lang['strinstatement']}</b><br />" . $misc->printVal($sql). "</p>	";*/
-
-			$s = "<p><b>strsqlerror</b><br />" . $errmsg . "</p> <p><b>SQL:</b><br />" . $sql . "</p>	";
-
-			echo '<table class="error" cellpadding="5"><tr><td>' . $s . '</td></tr></table><br />' . "\n";
-
-			break;
-
-		case 'PCONNECT':
-		case 'CONNECT':
-			// do nothing;
-			break;
-		default:
-			$s = "$dbms error: [$errno: $errmsg] in $fn($p1, $p2)\n";
-			echo "<table class=\"error\" cellpadding=\"5\"><tr><td>{$s}</td></tr></table><br />\n";
-			break;
-		}
-
-		$tag = implode('', $btarray0);
-
-		\PC::debug(['errno' => $errno, 'fn' => $fn, 'errmsg' => $errmsg], $tag);
-
-		throw new \PHPPgAdmin\ADODB_Exception($dbms, $fn, $errno, $errmsg, $p1, $p2, $thisConnection);
-	}
-
-	public function getContainer() {
-		return $this->container;
-	}
-
-	/**
-	 * sets $_no_bottom_link boolean value
-	 * @param boolean $flag [description]
-	 */
-	function setNoBottomLink($flag) {
-		$this->_no_bottom_link = boolval($flag);
-		return $this;
-	}
-
-	/**
-	 * sets $_no_db_connection boolean value, allows to render scripts that do not need an active session
-	 * @param boolean $flag [description]
-	 */
-	function setNoDBConnection($flag) {
-		$this->_no_db_connection = boolval($flag);
-		return $this;
-	}
-
-	function setNoOutput($flag) {
-		$this->_no_output = boolval($flag);
-		return $this;
-	}
-
-	function getNoDBConnection() {
-		return $this->_no_db_connection;
-	}
-
-	/**
-	 * Creates a database accessor
-	 */
-	function getDatabaseAccessor($database = '', $server_id = null) {
-		$lang = $this->lang;
-
-		if ($server_id !== null) {
-			$this->server_id = $server_id;
-		}
-
-		$server_info = $this->getServerInfo($this->server_id);
-
-		if ($this->_no_db_connection || !isset($server_info['username'])) {
-			return null;
-		}
-
-		if ($this->data === null) {
-			$_connection = $this->getConnection($database, $this->server_id);
-
-			//$this->prtrace('_connection', $_connection);
-			if (!$_connection) {
-				die($lang['strloginfailed']);
-			}
-			// Get the name of the database driver we need to use.
-			// The description of the server is returned in $platform.
-			$_type = $_connection->getDriver($platform);
-
-			$this->prtrace(['type' => $_type, 'platform' => $platform, 'pgVersion' => $_connection->conn->pgVersion]);
-
-			if ($_type === null) {
-				die(sprintf($lang['strpostgresqlversionnotsupported'], $this->postgresqlMinVer));
-			}
-			$_type = '\PHPPgAdmin\Database\\' . $_type;
-
-			$this->setServerInfo('platform', $platform, $this->server_id);
-			$this->setServerInfo('pgVersion', $_connection->conn->pgVersion, $this->server_id);
-
-			// Create a database wrapper class for easy manipulation of the
-			// connection.
-
-			$this->data = new $_type($_connection->conn, $this->conf);
-			$this->data->platform = $_connection->platform;
-			$this->data->server_info = $server_info;
-			$this->data->conf = $this->conf;
-			$this->data->lang = $this->lang;
-
-			/* we work on UTF-8 only encoding */
-			$this->data->execute("SET client_encoding TO 'UTF-8'");
-
-			if ($this->data->hasByteaHexDefault()) {
-				$this->data->execute("SET bytea_output TO escape");
-			}
-
-		}
-
-		if ($this->_no_db_connection === false && $this->getDatabase() !== null && isset($_REQUEST['schema'])) {
-			$status = $this->data->setSchema($_REQUEST['schema']);
-
-			if ($status != 0) {
-				\Kint::dump($status);
-				echo $this->lang['strbadschema'];
-				exit;
-			}
-		}
-
-		return $this->data;
-	}
-	function getConnection($database = '', $server_id = null) {
-		$lang = $this->lang;
-
-		if ($this->_connection === null) {
-			if ($server_id !== null) {
-				$this->server_id = $server_id;
-			}
-			$server_info = $this->getServerInfo($this->server_id);
-			$database_to_use = $this->getDatabase($database);
-
-			// Perform extra security checks if this config option is set
-			if ($this->conf['extra_login_security']) {
-				// Disallowed logins if extra_login_security is enabled.
-				// These must be lowercase.
-				$bad_usernames = [
-					'pgsql' => 'pgsql',
-					'postgres' => 'postgres',
-					'root' => 'root',
-					'administrator' => 'administrator',
-				];
-
-				if (isset($server_info['username']) && array_key_exists(strtolower($server_info['username']), $bad_usernames)) {
-					unset($_SESSION['webdbLogin'][$this->server_id]);
-					$msg = $lang['strlogindisallowed'];
-					$this->prtrace('msg', $msg);
-					$login_controller = new LoginController($this->container);
-					return $login_controller->render();
-				}
-
-				if (!isset($server_info['password']) || $server_info['password'] == '') {
-					unset($_SESSION['webdbLogin'][$this->server_id]);
-					$msg = $lang['strlogindisallowed'];
-					$this->prtrace('msg', $msg);
-					$login_controller = new LoginController($this->container);
-					return $login_controller->render();
-				}
-			}
-			try {
-
-				// Create the connection object and make the connection
-				$this->_connection = new \PHPPgAdmin\Database\Connection(
-					$server_info['host'],
-					$server_info['port'],
-					$server_info['sslmode'],
-					$server_info['username'],
-					$server_info['password'],
-					$database_to_use
-				);
-
-			} catch (\PHPPgAdmin\ADODB_Exception $e) {
-				unset($_SESSION['webdbLogin'][$this->server_id]);
-				$msg = $lang['strloginfailed'];
-				$login_controller = new LoginController($this->container);
-				return $login_controller->render();
-			}
-
-		}
-		return $this->_connection;
-	}
-
-	function getDatabase($database = '') {
-
-		if ($this->server_id === null && !isset($_REQUEST['database'])) {
-			return null;
-		}
-
-		$server_info = $this->getServerInfo($this->server_id);
-
-		if ($this->server_id !== null && isset($server_info['useonlydefaultdb']) && $server_info['useonlydefaultdb'] === true) {
-			$this->database = $server_info['defaultdb'];
-		} else if ($database !== '') {
-			$this->database = $database;
-		} else if (isset($_REQUEST['database'])) {
-			// Connect to the current database
-			$this->database = $_REQUEST['database'];
-		} else {
-			// or if one is not specified then connect to the default database.
-			$this->database = $server_info['defaultdb'];
-		}
-
-		return $this->database;
-
-	}
-
-	/**
-	 * [setReloadBrowser description]
-	 * @param boolean $flag sets internal $_reload_browser var which will be passed to the footer methods
-	 */
-	function setReloadBrowser($flag) {
-		$this->_reload_browser = boolval($flag);
-		return $this;
-	}
-	/**
-	 * [setReloadBrowser description]
-	 * @param boolean $flag sets internal $_reload_drop_database var which will be passed to the footer methods
-	 */
-	function setReloadDropDatabase($flag) {
-		$this->_reload_drop_database = boolval($flag);
-		return $this;
-	}
-
-	public static function _cmp_desc($a, $b) {
-		return strcmp($a['desc'], $b['desc']);
-	}
-	/**
-	 * Checks if dumps are properly set up
-	 * @param $all (optional) True to check pg_dumpall, false to just check pg_dump
-	 * @return True, dumps are set up, false otherwise
-	 */
-	function isDumpEnabled($all = false) {
-		$info = $this->getServerInfo();
-
-		return !empty($info[$all ? 'pg_dumpall_path' : 'pg_dump_path']);
-	}
-
-	function setThemeConf($theme_conf) {
-
-		$this->conf['theme'] = $theme_conf;
-		//\PC::debug(['theme_conf' => $theme_conf, 'this->theme' => $this->conf['theme']], 'setThemeConf');
-		$this->view->offsetSet('theme', $this->conf['theme']);
-		return $this;
-	}
-
-	function getConf() {
-		return $this->conf;
-	}
-	/**
-	 * Sets the href tracking variable
-	 */
-	function setHREF() {
-		$this->href = $this->getHREF();
-		//\PC::debug($this->href, 'Misc::href');
-		return $this;
-
-	}
-
-	/**
-	 * Get a href query string, excluding objects below the given object type (inclusive)
-	 */
-	function getHREF($exclude_from = null) {
-		$href = [];
-		if (isset($_REQUEST['server']) && $exclude_from != 'server') {
-			$href[] = 'server=' . urlencode($_REQUEST['server']);
-		}
-		if (isset($_REQUEST['database']) && $exclude_from != 'database') {
-			$href[] = 'database=' . urlencode($_REQUEST['database']);
-		}
-		if (isset($_REQUEST['schema']) && $exclude_from != 'schema') {
-			$href[] = 'schema=' . urlencode($_REQUEST['schema']);
-		}
-
-		return htmlentities(implode('&', $href));
-	}
-
-	function getSubjectParams($subject) {
-		$plugin_manager = $this->plugin_manager;
-
-		$vars = [];
-
-		switch ($subject) {
-		case 'root':
-			$vars = [
-				'params' => [
-					'subject' => 'root',
-				],
-			];
-			break;
-		case 'server':
-			$vars = ['params' => [
-				'server' => $_REQUEST['server'],
-				'subject' => 'server',
-			]];
-			break;
-		case 'role':
-			$vars = ['params' => [
-				'server' => $_REQUEST['server'],
-				'subject' => 'role',
-				'action' => 'properties',
-				'rolename' => $_REQUEST['rolename'],
-			]];
-			break;
-		case 'database':
-			$vars = ['params' => [
-				'server' => $_REQUEST['server'],
-				'subject' => 'database',
-				'database' => $_REQUEST['database'],
-			]];
-			break;
-		case 'schema':
-			$vars = ['params' => [
-				'server' => $_REQUEST['server'],
-				'subject' => 'schema',
-				'database' => $_REQUEST['database'],
-				'schema' => $_REQUEST['schema'],
-			]];
-			break;
-		case 'table':
-			$vars = ['params' => [
-				'server' => $_REQUEST['server'],
-				'subject' => 'table',
-				'database' => $_REQUEST['database'],
-				'schema' => $_REQUEST['schema'],
-				'table' => $_REQUEST['table'],
-			]];
-			break;
-		case 'selectrows':
-			$vars = [
-				'url' => 'tables.php',
-				'params' => [
-					'server' => $_REQUEST['server'],
-					'subject' => 'table',
-					'database' => $_REQUEST['database'],
-					'schema' => $_REQUEST['schema'],
-					'table' => $_REQUEST['table'],
-					'action' => 'confselectrows',
-				]];
-			break;
-		case 'view':
-			$vars = ['params' => [
-				'server' => $_REQUEST['server'],
-				'subject' => 'view',
-				'database' => $_REQUEST['database'],
-				'schema' => $_REQUEST['schema'],
-				'view' => $_REQUEST['view'],
-			]];
-			break;
-		case 'matview':
-			$vars = ['params' => [
-				'server' => $_REQUEST['server'],
-				'subject' => 'matview',
-				'database' => $_REQUEST['database'],
-				'schema' => $_REQUEST['schema'],
-				'matview' => $_REQUEST['matview'],
-			]];
-			break;
-
-		case 'fulltext':
-		case 'ftscfg':
-			$vars = ['params' => [
-				'server' => $_REQUEST['server'],
-				'subject' => 'fulltext',
-				'database' => $_REQUEST['database'],
-				'schema' => $_REQUEST['schema'],
-				'action' => 'viewconfig',
-				'ftscfg' => $_REQUEST['ftscfg'],
-			]];
-			break;
-		case 'function':
-			$vars = ['params' => [
-				'server' => $_REQUEST['server'],
-				'subject' => 'function',
-				'database' => $_REQUEST['database'],
-				'schema' => $_REQUEST['schema'],
-				'function' => $_REQUEST['function'],
-				'function_oid' => $_REQUEST['function_oid'],
-			]];
-			break;
-		case 'aggregate':
-			$vars = ['params' => [
-				'server' => $_REQUEST['server'],
-				'subject' => 'aggregate',
-				'action' => 'properties',
-				'database' => $_REQUEST['database'],
-				'schema' => $_REQUEST['schema'],
-				'aggrname' => $_REQUEST['aggrname'],
-				'aggrtype' => $_REQUEST['aggrtype'],
-			]];
-			break;
-		case 'column':
-			if (isset($_REQUEST['table'])) {
-				$vars = ['params' => [
-					'server' => $_REQUEST['server'],
-					'subject' => 'column',
-					'database' => $_REQUEST['database'],
-					'schema' => $_REQUEST['schema'],
-					'table' => $_REQUEST['table'],
-					'column' => $_REQUEST['column'],
-				]];
-			} else {
-				$vars = ['params' => [
-					'server' => $_REQUEST['server'],
-					'subject' => 'column',
-					'database' => $_REQUEST['database'],
-					'schema' => $_REQUEST['schema'],
-					'view' => $_REQUEST['view'],
-					'column' => $_REQUEST['column'],
-				]];
-			}
-
-			break;
-		case 'plugin':
-			$vars = [
-				'url' => 'plugin.php',
-				'params' => [
-					'server' => $_REQUEST['server'],
-					'subject' => 'plugin',
-					'plugin' => $_REQUEST['plugin'],
-				]];
-
-			if (!is_null($plugin_manager->getPlugin($_REQUEST['plugin']))) {
-				$vars['params'] = array_merge($vars['params'], $plugin_manager->getPlugin($_REQUEST['plugin'])->get_subject_params());
-			}
-
-			break;
-		default:
-			return false;
-		}
-
-		if (!isset($vars['url'])) {
-			$vars['url'] = '/redirect';
-		}
-		//\PC::debug($vars, 'getSubjectParams');
-		if ($vars['url'] == '/redirect' && isset($vars['params']['subject'])) {
-			$vars['url'] = '/redirect/' . $vars['params']['subject'];
-			unset($vars['params']['subject']);
-		}
-
-		return $vars;
-	}
-
-	function getHREFSubject($subject) {
-		$vars = $this->getSubjectParams($subject);
-		return "{$vars['url']}?" . http_build_query($vars['params'], '', '&amp;');
-	}
-
-	/**
-	 * Sets the form tracking variable
-	 */
-	function setForm() {
-		$form = [];
-		if (isset($_REQUEST['server'])) {
-			$form[] = '<input type="hidden" name="server" value="' . htmlspecialchars($_REQUEST['server']) . '" />';
-		}
-		if (isset($_REQUEST['database'])) {
-			$form[] = '<input type="hidden" name="database" value="' . htmlspecialchars($_REQUEST['database']) . '" />';
-		}
-
-		if (isset($_REQUEST['schema'])) {
-			$form[] = '<input type="hidden" name="schema" value="' . htmlspecialchars($_REQUEST['schema']) . '" />';
-		}
-		$this->form = implode("\n", $form);
-		return $this->form;
-
-		//\PC::debug($this->form, 'Misc::form');
-	}
-
-	/**
-	 * Render a value into HTML using formatting rules specified
-	 * by a type name and parameters.
-	 *
-	 * @param $str The string to change
-	 *
-	 * @param $type Field type (optional), this may be an internal PostgreSQL type, or:
-	 *			yesno    - same as bool, but renders as 'Yes' or 'No'.
-	 *			pre      - render in a <pre> block.
-	 *			nbsp     - replace all spaces with &nbsp;'s
-	 *			verbatim - render exactly as supplied, no escaping what-so-ever.
-	 *			callback - render using a callback function supplied in the 'function' param.
-	 *
-	 * @param $params Type parameters (optional), known parameters:
-	 *			null     - string to display if $str is null, or set to TRUE to use a default 'NULL' string,
-	 *			           otherwise nothing is rendered.
-	 *			clip     - if true, clip the value to a fixed length, and append an ellipsis...
-	 *			cliplen  - the maximum length when clip is enabled (defaults to $conf['max_chars'])
-	 *			ellipsis - the string to append to a clipped value (defaults to $lang['strellipsis'])
-	 *			tag      - an HTML element name to surround the value.
-	 *			class    - a class attribute to apply to any surrounding HTML element.
-	 *			align    - an align attribute ('left','right','center' etc.)
-	 *			true     - (type='bool') the representation of true.
-	 *			false    - (type='bool') the representation of false.
-	 *			function - (type='callback') a function name, accepts args ($str, $params) and returns a rendering.
-	 *			lineno   - prefix each line with a line number.
-	 *			map      - an associative array.
-	 *
-	 * @return The HTML rendered value
-	 */
-	function printVal($str, $type = null, $params = []) {
-		$lang = $this->lang;
-		$data = $this->data;
-
-		// Shortcircuit for a NULL value
-		if (is_null($str)) {
-			return isset($params['null'])
-			? ($params['null'] === true ? '<i>NULL</i>' : $params['null'])
-			: '';
-		}
-
-		if (isset($params['map']) && isset($params['map'][$str])) {
-			$str = $params['map'][$str];
-		}
-
-		// Clip the value if the 'clip' parameter is true.
-		if (isset($params['clip']) && $params['clip'] === true) {
-			$maxlen = isset($params['cliplen']) && is_integer($params['cliplen']) ? $params['cliplen'] : $this->conf['max_chars'];
-			$ellipsis = isset($params['ellipsis']) ? $params['ellipsis'] : $lang['strellipsis'];
-			if (strlen($str) > $maxlen) {
-				$str = substr($str, 0, $maxlen - 1) . $ellipsis;
-			}
-		}
-
-		$out = '';
-
-		switch ($type) {
-		case 'int2':
-		case 'int4':
-		case 'int8':
-		case 'float4':
-		case 'float8':
-		case 'money':
-		case 'numeric':
-		case 'oid':
-		case 'xid':
-		case 'cid':
-		case 'tid':
-			$align = 'right';
-			$out = nl2br(htmlspecialchars($str));
-			break;
-		case 'yesno':
-			if (!isset($params['true'])) {
-				$params['true'] = $lang['stryes'];
-			}
-
-			if (!isset($params['false'])) {
-				$params['false'] = $lang['strno'];
-			}
-
-		// No break - fall through to boolean case.
-		case 'bool':
-		case 'boolean':
-			if (is_bool($str)) {
-				$str = $str ? 't' : 'f';
-			}
-
-			switch ($str) {
-			case 't':
-				$out = (isset($params['true']) ? $params['true'] : $lang['strtrue']);
-				$align = 'center';
-				break;
-			case 'f':
-				$out = (isset($params['false']) ? $params['false'] : $lang['strfalse']);
-				$align = 'center';
-				break;
-			default:
-				$out = htmlspecialchars($str);
-			}
-			break;
-		case 'bytea':
-			$tag = 'div';
-			$class = 'pre';
-			$out = $data->escapeBytea($str);
-			break;
-		case 'errormsg':
-			$tag = 'pre';
-			$class = 'error';
-			$out = htmlspecialchars($str);
-			break;
-		case 'pre':
-			$tag = 'pre';
-			$out = htmlspecialchars($str);
-			break;
-		case 'prenoescape':
-			$tag = 'pre';
-			$out = $str;
-			break;
-		case 'nbsp':
-			$out = nl2br(str_replace(' ', '&nbsp;', htmlspecialchars($str)));
-			break;
-		case 'verbatim':
-			$out = $str;
-			break;
-		case 'callback':
-			$out = $params['function']($str, $params);
-			break;
-		case 'prettysize':
-			if ($str == -1) {
-				$out = $lang['strnoaccess'];
-			} else {
-				$limit = 10 * 1024;
-				$mult = 1;
-				if ($str < $limit * $mult) {
-					$out = $str . ' ' . $lang['strbytes'];
-				} else {
-					$mult *= 1024;
-					if ($str < $limit * $mult) {
-						$out = floor(($str + $mult / 2) / $mult) . ' ' . $lang['strkb'];
-					} else {
-						$mult *= 1024;
-						if ($str < $limit * $mult) {
-							$out = floor(($str + $mult / 2) / $mult) . ' ' . $lang['strmb'];
-						} else {
-							$mult *= 1024;
-							if ($str < $limit * $mult) {
-								$out = floor(($str + $mult / 2) / $mult) . ' ' . $lang['strgb'];
-							} else {
-								$mult *= 1024;
-								if ($str < $limit * $mult) {
-									$out = floor(($str + $mult / 2) / $mult) . ' ' . $lang['strtb'];
-								}
-
-							}
-						}
-					}
-				}
-			}
-			break;
-		default:
-			// If the string contains at least one instance of >1 space in a row, a tab
-			// character, a space at the start of a line, or a space at the start of
-			// the whole string then render within a pre-formatted element (<pre>).
-			if (preg_match('/(^ |  |\t|\n )/m', $str)) {
-				$tag = 'pre';
-				$class = 'data';
-				$out = htmlspecialchars($str);
-			} else {
-				$out = nl2br(htmlspecialchars($str));
-			}
-		}
-
-		if (isset($params['class'])) {
-			$class = $params['class'];
-		}
-
-		if (isset($params['align'])) {
-			$align = $params['align'];
-		}
-
-		if (!isset($tag) && (isset($class) || isset($align))) {
-			$tag = 'div';
-		}
-
-		if (isset($tag)) {
-			$alignattr = isset($align) ? " style=\"text-align: {$align}\"" : '';
-			$classattr = isset($class) ? " class=\"{$class}\"" : '';
-			$out = "<{$tag}{$alignattr}{$classattr}>{$out}</{$tag}>";
-		}
-
-		// Add line numbers if 'lineno' param is true
-		if (isset($params['lineno']) && $params['lineno'] === true) {
-			$lines = explode("\n", $str);
-			$num = count($lines);
-			if ($num > 0) {
-				$temp = "<table>\n<tr><td class=\"{$class}\" style=\"vertical-align: top; padding-right: 10px;\"><pre class=\"{$class}\">";
-				for ($i = 1; $i <= $num; $i++) {
-					$temp .= $i . "\n";
-				}
-				$temp .= "</pre></td><td class=\"{$class}\" style=\"vertical-align: top;\">{$out}</td></tr></table>\n";
-				$out = $temp;
-			}
-			unset($lines);
-		}
-
-		return $out;
-	}
-
-	/**
-	 * A function to recursively strip slashes.  Used to
-	 * enforce magic_quotes_gpc being off.
-	 * @param &var The variable to strip
-	 */
-	function stripVar(&$var) {
-		if (is_array($var)) {
-			foreach ($var as $k => $v) {
-				$this->stripVar($var[$k]);
-
-				/* magic_quotes_gpc escape keys as well ...*/
-				if (is_string($k)) {
-					$ek = stripslashes($k);
-					if ($ek !== $k) {
-						$var[$ek] = $var[$k];
-						unset($var[$k]);
-					}
-				}
-			}
-		} else {
-			$var = stripslashes($var);
-		}
-
-	}
-
-	/**
-	 * Print out the page heading and help link
-	 * @param $title Title, already escaped
-	 * @param $help (optional) The identifier for the help link
-
-	function printTitle($title, $help = null, $do_print = true) {
-	$data = $this->data;
-	$lang = $this->lang;
-
-	$title_html = "<h2>";
-	$title_html .= $this->printHelp($title, $help, false);
-	$title_html .= "</h2>\n";
-
-	if ($do_print) {
-	echo $title_html;
-	} else {
-	return $title_html;
-	}
-	} */
-
-	/**
-	 * Print out a message
-	 * @param $msg The message to print
-	 */
-	function printMsg($msg, $do_print = true) {
-		$html = '';
-		if ($msg != '') {
-			$html .= "<p class=\"message\">{$msg}</p>\n";
-		}
-		if ($do_print) {
-			echo $html;
-		} else {
-			return $html;
-		}
-
-	}
-
-	/**
-	 * Prints the page header.  If member variable $this->_no_output is
-	 * set then no header is drawn.
-	 * @param $title The title of the page
-	 * @param $script script tag
-	 * @param $do_print boolean if false, the function will return the header content
-
-	function printHeader($title = '', $script = null, $do_print = true, $template = 'header.twig') {
-
-	if (function_exists('newrelic_disable_autorum')) {
-	newrelic_disable_autorum();
-	}
-	$appName = $this->appName;
-	$lang = $this->lang;
-	$plugin_manager = $this->plugin_manager;
-
-	$viewVars = $this->lang;
-	$viewVars['dir'] = (strcasecmp($lang['applangdir'], 'ltr') != 0) ? ' dir="' . htmlspecialchars($lang['applangdir']) . '"' : '';
-
-	$viewVars['appName'] = htmlspecialchars($this->appName) . ($title != '') ? htmlspecialchars(" - {$title}") : '';
-
-	$header_html = $this->view->fetch($template, $viewVars);
-
-	if ($script) {
-	$header_html .= "{$script}\n";
-	}
-
-	$plugins_head = [];
-	$_params = ['heads' => &$plugins_head];
-
-	$plugin_manager->do_hook('head', $_params);
-
-	foreach ($plugins_head as $tag) {
-	$header_html .= $tag;
-	}
-
-	$header_html .= "</head>\n";
-
-	if (!$this->_no_output && $do_print) {
-
-	header("Content-Type: text/html; charset=utf-8");
-	echo $header_html;
-
-	} else {
-	return $header_html;
-	}
-	}*/
-
-	/**
-	 * Retrieve the tab info for a specific tab bar.
-	 * @param $section The name of the tab bar.
-	 */
-	function getNavTabs($section) {
-
-		$data = $this->data;
-		$lang = $this->lang;
-		$plugin_manager = $this->plugin_manager;
-
-		$hide_advanced = ($this->conf['show_advanced'] === false);
-		$tabs = [];
-
-		switch ($section) {
-		case 'root':
-			$tabs = [
-				'intro' => [
-					'title' => $lang['strintroduction'],
-					'url' => "intro.php",
-					'icon' => 'Introduction',
-				],
-				'servers' => [
-					'title' => $lang['strservers'],
-					'url' => "servers.php",
-					'icon' => 'Servers',
-				],
-			];
-			break;
-
-		case 'server':
-			$hide_users = true;
-			if ($data) {
-				$hide_users = !$data->isSuperUser();
-			}
-
-			$tabs = [
-				'databases' => [
-					'title' => $lang['strdatabases'],
-					'url' => 'all_db.php',
-					'urlvars' => ['subject' => 'server'],
-					'help' => 'pg.database',
-					'icon' => 'Databases',
-				],
-			];
-			if ($data && $data->hasRoles()) {
-				$tabs = array_merge($tabs, [
-					'roles' => [
-						'title' => $lang['strroles'],
-						'url' => 'roles.php',
-						'urlvars' => ['subject' => 'server'],
-						'hide' => $hide_users,
-						'help' => 'pg.role',
-						'icon' => 'Roles',
-					],
-				]);
-			} else {
-				$tabs = array_merge($tabs, [
-					'users' => [
-						'title' => $lang['strusers'],
-						'url' => 'users.php',
-						'urlvars' => ['subject' => 'server'],
-						'hide' => $hide_users,
-						'help' => 'pg.user',
-						'icon' => 'Users',
-					],
-					'groups' => [
-						'title' => $lang['strgroups'],
-						'url' => 'groups.php',
-						'urlvars' => ['subject' => 'server'],
-						'hide' => $hide_users,
-						'help' => 'pg.group',
-						'icon' => 'UserGroups',
-					],
-				]);
-			}
-
-			$tabs = array_merge($tabs, [
-				'account' => [
-					'title' => $lang['straccount'],
-					'url' => ($data && $data->hasRoles()) ? 'roles.php' : 'users.php',
-					'urlvars' => ['subject' => 'server', 'action' => 'account'],
-					'hide' => !$hide_users,
-					'help' => 'pg.role',
-					'icon' => 'User',
-				],
-				'tablespaces' => [
-					'title' => $lang['strtablespaces'],
-					'url' => 'tablespaces.php',
-					'urlvars' => ['subject' => 'server'],
-					'hide' => (!$data || !$data->hasTablespaces()),
-					'help' => 'pg.tablespace',
-					'icon' => 'Tablespaces',
-				],
-				'export' => [
-					'title' => $lang['strexport'],
-					'url' => 'all_db.php',
-					'urlvars' => ['subject' => 'server', 'action' => 'export'],
-					'hide' => (!$this->isDumpEnabled()),
-					'icon' => 'Export',
-				],
-			]);
-			break;
-		case 'database':
-			$tabs = [
-				'schemas' => [
-					'title' => $lang['strschemas'],
-					'url' => 'schemas.php',
-					'urlvars' => ['subject' => 'database'],
-					'help' => 'pg.schema',
-					'icon' => 'Schemas',
-				],
-				'sql' => [
-					'title' => $lang['strsql'],
-					'url' => 'database.php',
-					'urlvars' => ['subject' => 'database', 'action' => 'sql', 'new' => 1],
-					'help' => 'pg.sql',
-					'tree' => false,
-					'icon' => 'SqlEditor',
-				],
-				'find' => [
-					'title' => $lang['strfind'],
-					'url' => 'database.php',
-					'urlvars' => ['subject' => 'database', 'action' => 'find'],
-					'tree' => false,
-					'icon' => 'Search',
-				],
-				'variables' => [
-					'title' => $lang['strvariables'],
-					'url' => 'database.php',
-					'urlvars' => ['subject' => 'database', 'action' => 'variables'],
-					'help' => 'pg.variable',
-					'tree' => false,
-					'icon' => 'Variables',
-				],
-				'processes' => [
-					'title' => $lang['strprocesses'],
-					'url' => 'database.php',
-					'urlvars' => ['subject' => 'database', 'action' => 'processes'],
-					'help' => 'pg.process',
-					'tree' => false,
-					'icon' => 'Processes',
-				],
-				'locks' => [
-					'title' => $lang['strlocks'],
-					'url' => 'database.php',
-					'urlvars' => ['subject' => 'database', 'action' => 'locks'],
-					'help' => 'pg.locks',
-					'tree' => false,
-					'icon' => 'Key',
-				],
-				'admin' => [
-					'title' => $lang['stradmin'],
-					'url' => 'database.php',
-					'urlvars' => ['subject' => 'database', 'action' => 'admin'],
-					'tree' => false,
-					'icon' => 'Admin',
-				],
-				'privileges' => [
-					'title' => $lang['strprivileges'],
-					'url' => 'privileges.php',
-					'urlvars' => ['subject' => 'database'],
-					'hide' => (!isset($data->privlist['database'])),
-					'help' => 'pg.privilege',
-					'tree' => false,
-					'icon' => 'Privileges',
-				],
-				'languages' => [
-					'title' => $lang['strlanguages'],
-					'url' => 'languages.php',
-					'urlvars' => ['subject' => 'database'],
-					'hide' => $hide_advanced,
-					'help' => 'pg.language',
-					'icon' => 'Languages',
-				],
-				'casts' => [
-					'title' => $lang['strcasts'],
-					'url' => 'casts.php',
-					'urlvars' => ['subject' => 'database'],
-					'hide' => ($hide_advanced),
-					'help' => 'pg.cast',
-					'icon' => 'Casts',
-				],
-				'export' => [
-					'title' => $lang['strexport'],
-					'url' => 'database.php',
-					'urlvars' => ['subject' => 'database', 'action' => 'export'],
-					'hide' => (!$this->isDumpEnabled()),
-					'tree' => false,
-					'icon' => 'Export',
-				],
-			];
-			break;
-
-		case 'schema':
-			$tabs = [
-				'tables' => [
-					'title' => $lang['strtables'],
-					'url' => 'tables.php',
-					'urlvars' => ['subject' => 'schema'],
-					'help' => 'pg.table',
-					'icon' => 'Tables',
-				],
-				'views' => [
-					'title' => $lang['strviews'],
-					'url' => 'views.php',
-					'urlvars' => ['subject' => 'schema'],
-					'help' => 'pg.view',
-					'icon' => 'Views',
-				],
-				'matviews' => [
-					'title' => 'M ' . $lang['strviews'],
-					'url' => 'materialized_views.php',
-					'urlvars' => ['subject' => 'schema'],
-					'help' => 'pg.matview',
-					'icon' => 'MViews',
-				],
-				'sequences' => [
-					'title' => $lang['strsequences'],
-					'url' => 'sequences.php',
-					'urlvars' => ['subject' => 'schema'],
-					'help' => 'pg.sequence',
-					'icon' => 'Sequences',
-				],
-				'functions' => [
-					'title' => $lang['strfunctions'],
-					'url' => 'functions.php',
-					'urlvars' => ['subject' => 'schema'],
-					'help' => 'pg.function',
-					'icon' => 'Functions',
-				],
-				'fulltext' => [
-					'title' => $lang['strfulltext'],
-					'url' => 'fulltext.php',
-					'urlvars' => ['subject' => 'schema'],
-					'help' => 'pg.fts',
-					'tree' => true,
-					'icon' => 'Fts',
-				],
-				'domains' => [
-					'title' => $lang['strdomains'],
-					'url' => 'domains.php',
-					'urlvars' => ['subject' => 'schema'],
-					'help' => 'pg.domain',
-					'icon' => 'Domains',
-				],
-				'aggregates' => [
-					'title' => $lang['straggregates'],
-					'url' => 'aggregates.php',
-					'urlvars' => ['subject' => 'schema'],
-					'hide' => $hide_advanced,
-					'help' => 'pg.aggregate',
-					'icon' => 'Aggregates',
-				],
-				'types' => [
-					'title' => $lang['strtypes'],
-					'url' => 'types.php',
-					'urlvars' => ['subject' => 'schema'],
-					'hide' => $hide_advanced,
-					'help' => 'pg.type',
-					'icon' => 'Types',
-				],
-				'operators' => [
-					'title' => $lang['stroperators'],
-					'url' => 'operators.php',
-					'urlvars' => ['subject' => 'schema'],
-					'hide' => $hide_advanced,
-					'help' => 'pg.operator',
-					'icon' => 'Operators',
-				],
-				'opclasses' => [
-					'title' => $lang['stropclasses'],
-					'url' => 'opclasses.php',
-					'urlvars' => ['subject' => 'schema'],
-					'hide' => $hide_advanced,
-					'help' => 'pg.opclass',
-					'icon' => 'OperatorClasses',
-				],
-				'conversions' => [
-					'title' => $lang['strconversions'],
-					'url' => 'conversions.php',
-					'urlvars' => ['subject' => 'schema'],
-					'hide' => $hide_advanced,
-					'help' => 'pg.conversion',
-					'icon' => 'Conversions',
-				],
-				'privileges' => [
-					'title' => $lang['strprivileges'],
-					'url' => 'privileges.php',
-					'urlvars' => ['subject' => 'schema'],
-					'help' => 'pg.privilege',
-					'tree' => false,
-					'icon' => 'Privileges',
-				],
-				'export' => [
-					'title' => $lang['strexport'],
-					'url' => 'schemas.php',
-					'urlvars' => ['subject' => 'schema', 'action' => 'export'],
-					'hide' => (!$this->isDumpEnabled()),
-					'tree' => false,
-					'icon' => 'Export',
-				],
-			];
-			if (!$data->hasFTS()) {
-				unset($tabs['fulltext']);
-			}
-
-			break;
-
-		case 'table':
-			$tabs = [
-				'columns' => [
-					'title' => $lang['strcolumns'],
-					'url' => 'tblproperties.php',
-					'urlvars' => ['subject' => 'table', 'table' => Decorator::field('table')],
-					'icon' => 'Columns',
-					'branch' => true,
-				],
-				'browse' => [
-					'title' => $lang['strbrowse'],
-					'icon' => 'Columns',
-					'url' => 'display.php',
-					'urlvars' => ['subject' => 'table', 'table' => Decorator::field('table')],
-					'return' => 'table',
-					'branch' => true,
-				],
-				'select' => [
-					'title' => $lang['strselect'],
-					'icon' => 'Search',
-					'url' => 'tables.php',
-					'urlvars' => ['subject' => 'table', 'table' => Decorator::field('table'), 'action' => 'confselectrows'],
-					'help' => 'pg.sql.select',
-				],
-				'insert' => [
-					'title' => $lang['strinsert'],
-					'url' => 'tables.php',
-					'urlvars' => [
-						'action' => 'confinsertrow',
-						'table' => Decorator::field('table'),
-					],
-					'help' => 'pg.sql.insert',
-					'icon' => 'Operator',
-				],
-				'indexes' => [
-					'title' => $lang['strindexes'],
-					'url' => 'indexes.php',
-					'urlvars' => ['subject' => 'table', 'table' => Decorator::field('table')],
-					'help' => 'pg.index',
-					'icon' => 'Indexes',
-					'branch' => true,
-				],
-				'constraints' => [
-					'title' => $lang['strconstraints'],
-					'url' => 'constraints.php',
-					'urlvars' => ['subject' => 'table', 'table' => Decorator::field('table')],
-					'help' => 'pg.constraint',
-					'icon' => 'Constraints',
-					'branch' => true,
-				],
-				'triggers' => [
-					'title' => $lang['strtriggers'],
-					'url' => 'triggers.php',
-					'urlvars' => ['subject' => 'table', 'table' => Decorator::field('table')],
-					'help' => 'pg.trigger',
-					'icon' => 'Triggers',
-					'branch' => true,
-				],
-				'rules' => [
-					'title' => $lang['strrules'],
-					'url' => 'rules.php',
-					'urlvars' => ['subject' => 'table', 'table' => Decorator::field('table')],
-					'help' => 'pg.rule',
-					'icon' => 'Rules',
-					'branch' => true,
-				],
-				'admin' => [
-					'title' => $lang['stradmin'],
-					'url' => 'tables.php',
-					'urlvars' => ['subject' => 'table', 'table' => Decorator::field('table'), 'action' => 'admin'],
-					'icon' => 'Admin',
-				],
-				'info' => [
-					'title' => $lang['strinfo'],
-					'url' => 'info.php',
-					'urlvars' => ['subject' => 'table', 'table' => Decorator::field('table')],
-					'icon' => 'Statistics',
-				],
-				'privileges' => [
-					'title' => $lang['strprivileges'],
-					'url' => 'privileges.php',
-					'urlvars' => ['subject' => 'table', 'table' => Decorator::field('table')],
-					'help' => 'pg.privilege',
-					'icon' => 'Privileges',
-				],
-				'import' => [
-					'title' => $lang['strimport'],
-					'url' => 'tblproperties.php',
-					'urlvars' => ['subject' => 'table', 'table' => Decorator::field('table'), 'action' => 'import'],
-					'icon' => 'Import',
-					'hide' => false,
-				],
-				'export' => [
-					'title' => $lang['strexport'],
-					'url' => 'tblproperties.php',
-					'urlvars' => ['subject' => 'table', 'table' => Decorator::field('table'), 'action' => 'export'],
-					'icon' => 'Export',
-					'hide' => false,
-				],
-			];
-			break;
-
-		case 'view':
-			$tabs = [
-				'columns' => [
-					'title' => $lang['strcolumns'],
-					'url' => 'viewproperties.php',
-					'urlvars' => ['subject' => 'view', 'view' => Decorator::field('view')],
-					'icon' => 'Columns',
-					'branch' => true,
-				],
-				'browse' => [
-					'title' => $lang['strbrowse'],
-					'icon' => 'Columns',
-					'url' => 'display.php',
-					'urlvars' => [
-						'action' => 'confselectrows',
-						'return' => 'schema',
-						'subject' => 'view',
-						'view' => Decorator::field('view'),
-					],
-					'branch' => true,
-				],
-				'select' => [
-					'title' => $lang['strselect'],
-					'icon' => 'Search',
-					'url' => 'views.php',
-					'urlvars' => ['action' => 'confselectrows', 'view' => Decorator::field('view')],
-					'help' => 'pg.sql.select',
-				],
-				'definition' => [
-					'title' => $lang['strdefinition'],
-					'url' => 'viewproperties.php',
-					'urlvars' => ['subject' => 'view', 'view' => Decorator::field('view'), 'action' => 'definition'],
-					'icon' => 'Definition',
-				],
-				'rules' => [
-					'title' => $lang['strrules'],
-					'url' => 'rules.php',
-					'urlvars' => ['subject' => 'view', 'view' => Decorator::field('view')],
-					'help' => 'pg.rule',
-					'icon' => 'Rules',
-					'branch' => true,
-				],
-				'privileges' => [
-					'title' => $lang['strprivileges'],
-					'url' => 'privileges.php',
-					'urlvars' => ['subject' => 'view', 'view' => Decorator::field('view')],
-					'help' => 'pg.privilege',
-					'icon' => 'Privileges',
-				],
-				'export' => [
-					'title' => $lang['strexport'],
-					'url' => 'viewproperties.php',
-					'urlvars' => ['subject' => 'view', 'view' => Decorator::field('view'), 'action' => 'export'],
-					'icon' => 'Export',
-					'hide' => false,
-				],
-			];
-			break;
-
-		case 'matview':
-			$tabs = [
-				'columns' => [
-					'title' => $lang['strcolumns'],
-					'url' => 'materializedviewproperties.php',
-					'urlvars' => ['subject' => 'matview', 'matview' => Decorator::field('matview')],
-					'icon' => 'Columns',
-					'branch' => true,
-				],
-				'browse' => [
-					'title' => $lang['strbrowse'],
-					'icon' => 'Columns',
-					'url' => 'display.php',
-					'urlvars' => [
-						'action' => 'confselectrows',
-						'return' => 'schema',
-						'subject' => 'matview',
-						'matview' => Decorator::field('matview'),
-					],
-					'branch' => true,
-				],
-				'select' => [
-					'title' => $lang['strselect'],
-					'icon' => 'Search',
-					'url' => 'materialized_views.php',
-					'urlvars' => ['action' => 'confselectrows', 'matview' => Decorator::field('matview')],
-					'help' => 'pg.sql.select',
-				],
-				'definition' => [
-					'title' => $lang['strdefinition'],
-					'url' => 'materializedviewproperties.php',
-					'urlvars' => ['subject' => 'matview', 'matview' => Decorator::field('matview'), 'action' => 'definition'],
-					'icon' => 'Definition',
-				],
-				'indexes' => [
-					'title' => $lang['strindexes'],
-					'url' => 'indexes.php',
-					'urlvars' => ['subject' => 'matview', 'matview' => Decorator::field('matview')],
-					'help' => 'pg.index',
-					'icon' => 'Indexes',
-					'branch' => true,
-				],
-				/*'constraints' => [
-					'title' => $lang['strconstraints'],
-					'url' => 'constraints.php',
-					'urlvars' => ['subject' => 'matview', 'matview' => Decorator::field('matview')],
-					'help' => 'pg.constraint',
-					'icon' => 'Constraints',
-					'branch' => true,
-				],*/
-
-				'rules' => [
-					'title' => $lang['strrules'],
-					'url' => 'rules.php',
-					'urlvars' => ['subject' => 'matview', 'matview' => Decorator::field('matview')],
-					'help' => 'pg.rule',
-					'icon' => 'Rules',
-					'branch' => true,
-				],
-				'privileges' => [
-					'title' => $lang['strprivileges'],
-					'url' => 'privileges.php',
-					'urlvars' => ['subject' => 'matview', 'matview' => Decorator::field('matview')],
-					'help' => 'pg.privilege',
-					'icon' => 'Privileges',
-				],
-				'export' => [
-					'title' => $lang['strexport'],
-					'url' => 'materializedviewproperties.php',
-					'urlvars' => ['subject' => 'matview', 'matview' => Decorator::field('matview'), 'action' => 'export'],
-					'icon' => 'Export',
-					'hide' => false,
-				],
-			];
-			break;
-
-		case 'function':
-			$tabs = [
-				'definition' => [
-					'title' => $lang['strdefinition'],
-					'url' => 'functions.php',
-					'urlvars' => [
-						'subject' => 'function',
-						'function' => Decorator::field('function'),
-						'function_oid' => Decorator::field('function_oid'),
-						'action' => 'properties',
-					],
-					'icon' => 'Definition',
-				],
-				'privileges' => [
-					'title' => $lang['strprivileges'],
-					'url' => 'privileges.php',
-					'urlvars' => [
-						'subject' => 'function',
-						'function' => Decorator::field('function'),
-						'function_oid' => Decorator::field('function_oid'),
-					],
-					'icon' => 'Privileges',
-				],
-			];
-			break;
-
-		case 'aggregate':
-			$tabs = [
-				'definition' => [
-					'title' => $lang['strdefinition'],
-					'url' => 'aggregates.php',
-					'urlvars' => [
-						'subject' => 'aggregate',
-						'aggrname' => Decorator::field('aggrname'),
-						'aggrtype' => Decorator::field('aggrtype'),
-						'action' => 'properties',
-					],
-					'icon' => 'Definition',
-				],
-			];
-			break;
-
-		case 'role':
-			$tabs = [
-				'definition' => [
-					'title' => $lang['strdefinition'],
-					'url' => 'roles.php',
-					'urlvars' => [
-						'subject' => 'role',
-						'rolename' => Decorator::field('rolename'),
-						'action' => 'properties',
-					],
-					'icon' => 'Definition',
-				],
-			];
-			break;
-
-		case 'popup':
-			$tabs = [
-				'sql' => [
-					'title' => $lang['strsql'],
-					'url' => '/src/views/sqledit.php',
-					'urlvars' => ['action' => 'sql', 'subject' => 'schema'],
-					'help' => 'pg.sql',
-					'icon' => 'SqlEditor',
-				],
-				'find' => [
-					'title' => $lang['strfind'],
-					'url' => '/src/views/sqledit.php',
-					'urlvars' => ['action' => 'find', 'subject' => 'schema'],
-					'icon' => 'Search',
-				],
-			];
-			break;
-
-		case 'column':
-			$tabs = [
-				'properties' => [
-					'title' => $lang['strcolprop'],
-					'url' => 'colproperties.php',
-					'urlvars' => [
-						'subject' => 'column',
-						'table' => Decorator::field('table'),
-						'column' => Decorator::field('column'),
-					],
-					'icon' => 'Column',
-				],
-				'privileges' => [
-					'title' => $lang['strprivileges'],
-					'url' => 'privileges.php',
-					'urlvars' => [
-						'subject' => 'column',
-						'table' => Decorator::field('table'),
-						'column' => Decorator::field('column'),
-					],
-					'help' => 'pg.privilege',
-					'icon' => 'Privileges',
-				],
-			];
-			break;
-
-		case 'fulltext':
-			$tabs = [
-				'ftsconfigs' => [
-					'title' => $lang['strftstabconfigs'],
-					'url' => 'fulltext.php',
-					'urlvars' => ['subject' => 'schema'],
-					'hide' => !$data->hasFTS(),
-					'help' => 'pg.ftscfg',
-					'tree' => true,
-					'icon' => 'FtsCfg',
-				],
-				'ftsdicts' => [
-					'title' => $lang['strftstabdicts'],
-					'url' => 'fulltext.php',
-					'urlvars' => ['subject' => 'schema', 'action' => 'viewdicts'],
-					'hide' => !$data->hasFTS(),
-					'help' => 'pg.ftsdict',
-					'tree' => true,
-					'icon' => 'FtsDict',
-				],
-				'ftsparsers' => [
-					'title' => $lang['strftstabparsers'],
-					'url' => 'fulltext.php',
-					'urlvars' => ['subject' => 'schema', 'action' => 'viewparsers'],
-					'hide' => !$data->hasFTS(),
-					'help' => 'pg.ftsparser',
-					'tree' => true,
-					'icon' => 'FtsParser',
-				],
-			];
-			break;
-		}
-
-		// Tabs hook's place
-		$plugin_functions_parameters = [
-			'tabs' => &$tabs,
-			'section' => $section,
-		];
-		$plugin_manager->do_hook('tabs', $plugin_functions_parameters);
-
-		return $tabs;
-	}
-
-	/**
-	 * Get the URL for the last active tab of a particular tab bar.
-	 */
-	function getLastTabURL($section) {
-		$data = $this->getDatabaseAccessor();
-
-		$tabs = $this->getNavTabs($section);
-
-		if (isset($_SESSION['webdbLastTab'][$section]) && isset($tabs[$_SESSION['webdbLastTab'][$section]])) {
-			$tab = $tabs[$_SESSION['webdbLastTab'][$section]];
-		} else {
-			$tab = reset($tabs);
-		}
-		\PC::debug(['section' => $section, 'tabs' => $tabs, 'tab' => $tab], 'getLastTabURL');
-		return isset($tab['url']) ? $tab : null;
-	}
-
-	/**
-	 * Do multi-page navigation.  Displays the prev, next and page options.
-	 * @param $page - the page currently viewed
-	 * @param $pages - the maximum number of pages
-	 * @param $gets -  the parameters to include in the link to the wanted page
-	 * @param $max_width - the number of pages to make available at any one time (default = 20)
-	 */
-	function printPages($page, $pages, $gets, $max_width = 20) {
-		$lang = $this->lang;
-
-		$window = 10;
-
-		if ($page < 0 || $page > $pages) {
-			return;
-		}
-
-		if ($pages < 0) {
-			return;
-		}
-
-		if ($max_width <= 0) {
-			return;
-		}
-
-		unset($gets['page']);
-		$url = http_build_query($gets);
-
-		if ($pages > 1) {
-			echo "<p style=\"text-align: center\">\n";
-			if ($page != 1) {
-				echo "<a class=\"pagenav\" href=\"?{$url}&amp;page=1\">{$lang['strfirst']}</a>\n";
-				$temp = $page - 1;
-				echo "<a class=\"pagenav\" href=\"?{$url}&amp;page={$temp}\">{$lang['strprev']}</a>\n";
-			}
-
-			if ($page <= $window) {
-				$min_page = 1;
-				$max_page = min(2 * $window, $pages);
-			} elseif ($page > $window && $pages >= $page + $window) {
-				$min_page = ($page - $window) + 1;
-				$max_page = $page + $window;
-			} else {
-				$min_page = ($page - (2 * $window - ($pages - $page))) + 1;
-				$max_page = $pages;
-			}
-
-			// Make sure min_page is always at least 1
-			// and max_page is never greater than $pages
-			$min_page = max($min_page, 1);
-			$max_page = min($max_page, $pages);
-
-			for ($i = $min_page; $i <= $max_page; $i++) {
-				#if ($i != $page) echo "<a class=\"pagenav\" href=\"?{$url}&amp;page={$i}\">$i</a>\n";
-				if ($i != $page) {
-					echo "<a class=\"pagenav\" href=\"display.php?{$url}&amp;page={$i}\">$i</a>\n";
-				} else {
-					echo "$i\n";
-				}
-
-			}
-			if ($page != $pages) {
-				$temp = $page + 1;
-				echo "<a class=\"pagenav\" href=\"display.php?{$url}&amp;page={$temp}\">{$lang['strnext']}</a>\n";
-				echo "<a class=\"pagenav\" href=\"display.php?{$url}&amp;page={$pages}\">{$lang['strlast']}</a>\n";
-			}
-			echo "</p>\n";
-		}
-	}
-
-	/**
-	 * Displays link to the context help.
-	 * @param $str   - the string that the context help is related to (already escaped)
-	 * @param $help  - help section identifier
-	 * @param $do_print true to echo, false to return
-	 */
-	function printHelp($str, $help = null, $do_print = true) {
-		//\PC::debug(['str' => $str, 'help' => $help], 'printHelp');
-		if ($help !== null) {
-			$helplink = $this->getHelpLink($help);
-			$str .= '<a class="help" href="' . $helplink . '" title="' . $this->lang['strhelp'] . '" target="phppgadminhelp">' . $this->lang['strhelpicon'] . '</a>';
-
-		}
-		if ($do_print) {
-			echo $str;
-		} else {
-			return $str;
-		}
-	}
-
-	function getHelpLink($help) {
-		return htmlspecialchars("/src/views/help.php?help=" . urlencode($help) . "&server=" . urlencode($this->server_id));
-
-	}
-
-	/**
-	 * Converts a PHP.INI size variable to bytes.  Taken from publically available
-	 * function by Chris DeRose, here: http://www.php.net/manual/en/configuration.directives.php#ini.file-uploads
-	 * @param $strIniSize The PHP.INI variable
-	 * @return size in bytes, false on failure
-	 */
-	function inisizeToBytes($strIniSize) {
-		// This function will take the string value of an ini 'size' parameter,
-		// and return a double (64-bit float) representing the number of bytes
-		// that the parameter represents. Or false if $strIniSize is unparseable.
-		$a_IniParts = [];
-
-		if (!is_string($strIniSize)) {
-			return false;
-		}
-
-		if (!preg_match('/^(\d+)([bkm]*)$/i', $strIniSize, $a_IniParts)) {
-			return false;
-		}
-
-		$nSize = (double) $a_IniParts[1];
-		$strUnit = strtolower($a_IniParts[2]);
-
-		switch ($strUnit) {
-		case 'm':
-			return ($nSize * (double) 1048576);
-		case 'k':
-			return ($nSize * (double) 1024);
-		case 'b':
-		default:
-			return $nSize;
-		}
-	}
-
-	function getRequestVars($subject = '') {
-		$v = [];
-		if (!empty($subject)) {
-			$v['subject'] = $subject;
-		}
-
-		if ($this->server_id !== null && $subject != 'root') {
-			$v['server'] = $this->server_id;
-			if ($this->database !== null && $subject != 'server') {
-				$v['database'] = $this->database;
-				if (isset($_REQUEST['schema']) && $subject != 'database') {
-					$v['schema'] = $_REQUEST['schema'];
-				}
-			}
-		}
-		return $v;
-	}
-
-	function icon($icon) {
-		if (is_string($icon)) {
-			$path = "/images/themes/{$this->conf['theme']}/{$icon}";
-			if (file_exists(BASE_PATH . $path . '.png')) {
-				return $path . '.png';
-			}
-
-			if (file_exists(BASE_PATH . $path . '.gif')) {
-				return $path . '.gif';
-			}
-
-			$path = "/images/themes/default/{$icon}";
-			if (file_exists(BASE_PATH . $path . '.png')) {
-				return $path . '.png';
-			}
-
-			if (file_exists(BASE_PATH . $path . '.gif')) {
-				return $path . '.gif';
-			}
-
-		} else {
-			// Icon from plugins
-			$path = "/plugins/{$icon[0]}/images/{$icon[1]}";
-			if (file_exists(BASE_PATH . $path . '.png')) {
-				return $path . '.png';
-			}
-
-			if (file_exists(BASE_PATH . $path . '.gif')) {
-				return $path . '.gif';
-			}
-
-		}
-		return '';
-	}
-
-	/**
-	 * Function to escape command line parameters
-	 * @param $str The string to escape
-	 * @return The escaped string
-	 */
-	function escapeShellArg($str) {
-		$data = $this->getDatabaseAccessor();
-		$lang = $this->lang;
-
-		if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
-			// Due to annoying PHP bugs, shell arguments cannot be escaped
-			// (command simply fails), so we cannot allow complex objects
-			// to be dumped.
-			if (preg_match('/^[_.[:alnum:]]+$/', $str)) {
-				return $str;
-			} else {
-				echo $lang['strcannotdumponwindows'];
-				exit;
-			}
-		} else {
-			return escapeshellarg($str);
-		}
-
-	}
-
-	/**
-	 * Function to escape command line programs
-	 * @param $str The string to escape
-	 * @return The escaped string
-	 */
-	function escapeShellCmd($str) {
-		$data = $this->getDatabaseAccessor();
-
-		if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
-			$data->fieldClean($str);
-			return '"' . $str . '"';
-		} else {
-			return escapeshellcmd($str);
-		}
-
-	}
-
-	/**
-	 * Get list of servers' groups if existing in the conf
-	 * @return a recordset of servers' groups
-	 */
-	function getServersGroups($recordset = false, $group_id = false) {
-		$lang = $this->lang;
-		$grps = [];
-
-		if (isset($this->conf['srv_groups'])) {
-			foreach ($this->conf['srv_groups'] as $i => $group) {
-				if (
-					(($group_id === false) and (!isset($group['parents']))) /* root */
-					or (
-						($group_id !== false)
-						and isset($group['parents'])
-						and in_array($group_id, explode(',',
-							preg_replace('/\s/', '', $group['parents'])
-						))
-					) /* nested group */
-				) {
-					$grps[$i] = [
-						'id' => $i,
-						'desc' => $group['desc'],
-						'icon' => 'Servers',
-						'action' => Decorator::url('/views/servers',
-							[
-								'group' => Decorator::field('id'),
-							]
-						),
-						'branch' => Decorator::url('/tree/servers',
-							[
-								'group' => $i,
-							]
-						),
-					];
-				}
-
-			}
-
-			if ($group_id === false) {
-				$grps['all'] = [
-					'id' => 'all',
-					'desc' => $lang['strallservers'],
-					'icon' => 'Servers',
-					'action' => Decorator::url('/views/servers',
-						[
-							'group' => Decorator::field('id'),
-						]
-					),
-					'branch' => Decorator::url('/tree/servers',
-						[
-							'group' => 'all',
-						]
-					),
-				];
-			}
-
-		}
-
-		if ($recordset) {
-			return new ArrayRecordSet($grps);
-		}
-
-		return $grps;
-	}
-
-	/**
-	 * Get list of servers
-	 * @param $recordset return as RecordSet suitable for printTable if true,
-	 *                   otherwise just return an array.
-	 * @param $group a group name to filter the returned servers using $this->conf[srv_groups]
-	 */
-	function getServers($recordset = false, $group = false) {
-
-		$logins = isset($_SESSION['webdbLogin']) && is_array($_SESSION['webdbLogin']) ? $_SESSION['webdbLogin'] : [];
-		$srvs = [];
-
-		if (($group !== false) and ($group !== 'all')) {
-			if (isset($this->conf['srv_groups'][$group]['servers'])) {
-				$group = array_fill_keys(explode(',', preg_replace('/\s/', '',
-					$this->conf['srv_groups'][$group]['servers'])), 1);
-			} else {
-				$group = '';
-			}
-		}
-
-		foreach ($this->conf['servers'] as $idx => $info) {
-			$server_id = $info['host'] . ':' . $info['port'] . ':' . $info['sslmode'];
-			if (($group === false)
-				or (isset($group[$idx]))
-				or ($group === 'all')
-			) {
-				$server_id = $info['host'] . ':' . $info['port'] . ':' . $info['sslmode'];
-
-				if (isset($logins[$server_id])) {
-					$srvs[$server_id] = $logins[$server_id];
-				} else {
-					$srvs[$server_id] = $info;
-				}
-
-				$srvs[$server_id]['id'] = $server_id;
-				$srvs[$server_id]['action'] = Decorator::url('/redirect/server',
-					[
-						'server' => Decorator::field('id'),
-					]
-				);
-				if (isset($srvs[$server_id]['username'])) {
-					$srvs[$server_id]['icon'] = 'Server';
-					$srvs[$server_id]['branch'] = Decorator::url('all_db.php',
-						[
-							'action' => 'tree',
-							'subject' => 'server',
-							'server' => Decorator::field('id'),
-						]
-					);
-				} else {
-					$srvs[$server_id]['icon'] = 'DisconnectedServer';
-					$srvs[$server_id]['branch'] = false;
-				}
-			}
-		}
-
-		uasort($srvs, ['self', '_cmp_desc']);
-
-		if ($recordset) {
-			return new ArrayRecordSet($srvs);
-		}
-		return $srvs;
-	}
-
-	function getServerId() {
-		return $this->server_id;
-	}
-	/**
-	 * Validate and retrieve information on a server.
-	 * If the parameter isn't supplied then the currently
-	 * connected server is returned.
-	 * @param $server_id A server identifier (host:port)
-	 * @return An associative array of server properties
-	 */
-	function getServerInfo($server_id = null) {
-
-		//\PC::debug(['$server_id' => $server_id]);
-
-		if ($server_id !== null) {
-			$this->server_id = $server_id;
-		} else if ($this->server_info !== null) {
-			return $this->server_info;
-		}
-
-		// Check for the server in the logged-in list
-		if (isset($_SESSION['webdbLogin'][$this->server_id])) {
-			$this->server_info = $_SESSION['webdbLogin'][$this->server_id];
-			return $this->server_info;
-		}
-
-		// Otherwise, look for it in the conf file
-		foreach ($this->conf['servers'] as $idx => $info) {
-			if ($this->server_id == $info['host'] . ':' . $info['port'] . ':' . $info['sslmode']) {
-				// Automatically use shared credentials if available
-				if (!isset($info['username']) && isset($_SESSION['sharedUsername'])) {
-					$info['username'] = $_SESSION['sharedUsername'];
-					$info['password'] = $_SESSION['sharedPassword'];
-					$this->setReloadBrowser(true);
-					$this->setServerInfo(null, $info, $this->server_id);
-				}
-				$this->server_info = $info;
-				return $this->server_info;
-
-			}
-		}
-
-		if ($server_id === null) {
-			$this->server_info = null;
-			return $this->server_info;
-
-		} else {
-			$this->server_info = null;
-			// Unable to find a matching server, are we being hacked?
-			echo $this->lang['strinvalidserverparam'];
-
-			exit;
-		}
-	}
-
-	/**
-	 * Set server information.
-	 * @param $key parameter name to set, or null to replace all
-	 *             params with the assoc-array in $value.
-	 * @param $value the new value, or null to unset the parameter
-	 * @param $server_id the server identifier, or null for current
-	 *                   server.
-	 */
-	function setServerInfo($key, $value, $server_id = null) {
-		//\PC::debug('setsetverinfo');
-		if ($server_id === null && isset($_REQUEST['server'])) {
-			$server_id = $_REQUEST['server'];
-		}
-
-		if ($key === null) {
-			if ($value === null) {
-				unset($_SESSION['webdbLogin'][$server_id]);
-			} else {
-				//\PC::debug(['server_id' => $server_id, 'value' => $value], 'webdbLogin null key');
-				$_SESSION['webdbLogin'][$server_id] = $value;
-			}
-
-		} else {
-			if ($value === null) {
-				unset($_SESSION['webdbLogin'][$server_id][$key]);
-			} else {
-				//\PC::debug(['server_id' => $server_id, 'key' => $key, 'value' => $value], __FILE__ . ' ' . __LINE__ . ' webdbLogin key ' . $key);
-				$_SESSION['webdbLogin'][$server_id][$key] = $value;
-			}
-
-		}
-	}
-
-	/**
-	 * Set the current schema
-	 * @param $schema The schema name
-	 * @return 0 on success
-	 * @return $data->seSchema() on error
-	 */
-	function setCurrentSchema($schema) {
-		$data = $this->getDatabaseAccessor();
-
-		$status = $data->setSchema($schema);
-		if ($status != 0) {
-			return $status;
-		}
-
-		$_REQUEST['schema'] = $schema;
-		$this->setHREF();
-		return 0;
-	}
-
-	/**
-	 * Save the given SQL script in the history
-	 * of the database and server.
-	 * @param $script the SQL script to save.
-	 */
-	function saveScriptHistory($script) {
-		list($usec, $sec) = explode(' ', microtime());
-		$time = ((float) $usec + (float) $sec);
-		$_SESSION['history'][$_REQUEST['server']][$_REQUEST['database']]["$time"] = [
-			'query' => $script,
-			'paginate' => (!isset($_REQUEST['paginate']) ? 'f' : 't'),
-			'queryid' => $time,
-		];
-	}
-
-	/*
-		 * Output dropdown list to select server and
-		 * databases form the popups windows.
-		 * @param $onchange Javascript action to take when selections change.
-		 */
-	function printConnection($onchange, $do_print = true) {
-		$lang = $this->lang;
-
-		$connection_html = "<table class=\"printconnection\" style=\"width: 100%\"><tr><td class=\"popup_select1\">\n";
-
-		$servers = $this->getServers();
-		$forcedserver = null;
-		if (count($servers) === 1) {
-			$forcedserver = $this->server_id;
-			$connection_html .= '<input type="hidden" readonly="readonly" value="' . $this->server_id . '" name="server">';
-		} else {
-			$connection_html .= "<label>";
-			$connection_html .= $this->printHelp($lang['strserver'], 'pg.server', false);
-			$connection_html .= ": </label>";
-			$connection_html .= " <select name=\"server\" {$onchange}>\n";
-			foreach ($servers as $info) {
-				if (empty($info['username'])) {
-					continue;
-				}
-				$selected = ((isset($_REQUEST['server']) && $info['id'] == $_REQUEST['server'])) ? ' selected="selected"' : '';
-				// not logged on this server
-				$connection_html .= "<option value=\"" . htmlspecialchars($info['id']) . "\" " . $selected . ">";
-				$connection_html .= htmlspecialchars("{$info['desc']} ({$info['id']})");
-				$connection_html .= "</option>\n";
-			}
-			$connection_html .= "</select>\n";
-		}
-
-		$connection_html .= "</td><td class=\"popup_select2\" style=\"text-align: right\">\n";
-
-		if (count($servers) === 1 && isset($servers[$this->server_id]['useonlydefaultdb']) && $servers[$this->server_id]['useonlydefaultdb'] === true) {
-
-			$connection_html .= "<input type=\"hidden\" name=\"database\" value=\"" . htmlspecialchars($servers[$this->server_id]['defaultdb']) . "\" />\n";
-
-		} else {
-
-			// Get the list of all databases
-			$data = $this->getDatabaseAccessor();
-			$databases = $data->getDatabases();
-			if ($databases->recordCount() > 0) {
-
-				$connection_html .= "<label>";
-				$connection_html .= $this->printHelp($lang['strdatabase'], 'pg.database', false);
-				$connection_html .= ": <select name=\"database\" {$onchange}>\n";
-
-				//if no database was selected, user should select one
-				if (!isset($_REQUEST['database'])) {
-					$connection_html .= "<option value=\"\">--</option>\n";
-				}
-
-				while (!$databases->EOF) {
-					$dbname = $databases->fields['datname'];
-					$dbselected = ((isset($_REQUEST['database']) && $dbname == $_REQUEST['database'])) ? ' selected="selected"' : '';
-					$connection_html .= "<option value=\"" . htmlspecialchars($dbname) . "\" " . $dbselected . ">" . htmlspecialchars($dbname) . "</option>\n";
-
-					$databases->moveNext();
-				}
-				$connection_html .= "</select></label>\n";
-			} else {
-				$server_info = $misc->getServerInfo();
-				$connection_html .= "<input type=\"hidden\" name=\"database\" value=\"" . htmlspecialchars($server_info['defaultdb']) . "\" />\n";
-			}
-		}
-
-		$connection_html .= "</td></tr></table>\n";
-
-		if ($do_print) {
-			echo $connection_html;
-		} else {
-			return $connection_html;
-		}
-
-	}
-
-	/**
-	 * returns an array representing FKs definition for a table, sorted by fields
-	 * or by constraint.
-	 * @param $table The table to retrieve FK contraints from
-	 * @returns the array of FK definition:
-	 *   array(
-	 *     'byconstr' => array(
-	 *       constrain id => array(
-	 *         confrelid => foreign relation oid
-	 *         f_schema => foreign schema name
-	 *         f_table => foreign table name
-	 *         pattnums => array of parent's fields nums
-	 *         pattnames => array of parent's fields names
-	 *         fattnames => array of foreign attributes names
-	 *       )
-	 *     ),
-	 *     'byfield' => array(
-	 *       attribute num => array (constraint id, ...)
-	 *     ),
-	 *     'code' => HTML/js code to include in the page for auto-completion
-	 *   )
-	 **/
-	function getAutocompleteFKProperties($table) {
-		$data = $this->getDatabaseAccessor();
-
-		$fksprops = [
-			'byconstr' => [],
-			'byfield' => [],
-			'code' => '',
-		];
-
-		$constrs = $data->getConstraintsWithFields($table);
-
-		if (!$constrs->EOF) {
-			$conrelid = $constrs->fields['conrelid'];
-			while (!$constrs->EOF) {
-				if ($constrs->fields['contype'] == 'f') {
-					if (!isset($fksprops['byconstr'][$constrs->fields['conid']])) {
-						$fksprops['byconstr'][$constrs->fields['conid']] = [
-							'confrelid' => $constrs->fields['confrelid'],
-							'f_table' => $constrs->fields['f_table'],
-							'f_schema' => $constrs->fields['f_schema'],
-							'pattnums' => [],
-							'pattnames' => [],
-							'fattnames' => [],
-						];
-					}
-
-					$fksprops['byconstr'][$constrs->fields['conid']]['pattnums'][] = $constrs->fields['p_attnum'];
-					$fksprops['byconstr'][$constrs->fields['conid']]['pattnames'][] = $constrs->fields['p_field'];
-					$fksprops['byconstr'][$constrs->fields['conid']]['fattnames'][] = $constrs->fields['f_field'];
-
-					if (!isset($fksprops['byfield'][$constrs->fields['p_attnum']])) {
-						$fksprops['byfield'][$constrs->fields['p_attnum']] = [];
-					}
-
-					$fksprops['byfield'][$constrs->fields['p_attnum']][] = $constrs->fields['conid'];
-				}
-				$constrs->moveNext();
-			}
-
-			$fksprops['code'] = "<script type=\"text/javascript\">\n";
-			$fksprops['code'] .= "var constrs = {};\n";
-			foreach ($fksprops['byconstr'] as $conid => $props) {
-				$fksprops['code'] .= "constrs.constr_{$conid} = {\n";
-				$fksprops['code'] .= 'pattnums: [' . implode(',', $props['pattnums']) . "],\n";
-				$fksprops['code'] .= "f_table:'" . addslashes(htmlentities($props['f_table'], ENT_QUOTES, 'UTF-8')) . "',\n";
-				$fksprops['code'] .= "f_schema:'" . addslashes(htmlentities($props['f_schema'], ENT_QUOTES, 'UTF-8')) . "',\n";
-				$_ = '';
-				foreach ($props['pattnames'] as $n) {
-					$_ .= ",'" . htmlentities($n, ENT_QUOTES, 'UTF-8') . "'";
-				}
-				$fksprops['code'] .= 'pattnames: [' . substr($_, 1) . "],\n";
-
-				$_ = '';
-				foreach ($props['fattnames'] as $n) {
-					$_ .= ",'" . htmlentities($n, ENT_QUOTES, 'UTF-8') . "'";
-				}
-
-				$fksprops['code'] .= 'fattnames: [' . substr($_, 1) . "]\n";
-				$fksprops['code'] .= "};\n";
-			}
-
-			$fksprops['code'] .= "var attrs = {};\n";
-			foreach ($fksprops['byfield'] as $attnum => $cstrs) {
-				$fksprops['code'] .= "attrs.attr_{$attnum} = [" . implode(',', $fksprops['byfield'][$attnum]) . "];\n";
-			}
-
-			$fksprops['code'] .= "var table='" . addslashes(htmlentities($table, ENT_QUOTES, 'UTF-8')) . "';";
-			$fksprops['code'] .= "var server='" . htmlentities($_REQUEST['server'], ENT_QUOTES, 'UTF-8') . "';";
-			$fksprops['code'] .= "var database='" . addslashes(htmlentities($_REQUEST['database'], ENT_QUOTES, 'UTF-8')) . "';";
-			$fksprops['code'] .= "</script>\n";
-
-			$fksprops['code'] .= '<div id="fkbg"></div>';
-			$fksprops['code'] .= '<div id="fklist"></div>';
-			$fksprops['code'] .= '<script src="/js/ac_insert_row.js" type="text/javascript"></script>';
-		} else /* we have no foreign keys on this table */
-		{
-			return false;
-		}
-
-		return $fksprops;
-	}
+class Misc
+{
+
+    use \PHPPgAdmin\HelperTrait;
+
+    private $_connection           = null;
+    private $_no_db_connection     = false;
+    private $_reload_drop_database = false;
+    private $_reload_browser       = false;
+    private $_no_bottom_link       = false;
+    private $app                   = null;
+    private $data                  = null;
+    private $database              = null;
+    private $server_id             = null;
+    public $appLangFiles           = [];
+    public $appName                = '';
+    public $appVersion             = '';
+    public $form                   = '';
+    public $href                   = '';
+    public $_name                  = 'Misc';
+    public $lang                   = [];
+    private $server_info           = null;
+    private $_no_output            = false;
+    private $container             = null;
+
+    /* Constructor */
+    public function __construct(\Slim\Container $container)
+    {
+
+        $this->container = $container;
+
+        $this->lang           = $container->get('lang');
+        $this->conf           = $container->get('conf');
+        $this->view           = $container->get('view');
+        $this->plugin_manager = $container->get('plugin_manager');
+        $this->appLangFiles   = $container->get('appLangFiles');
+
+        $this->appName          = $container->get('settings')['appName'];
+        $this->appVersion       = $container->get('settings')['appVersion'];
+        $this->postgresqlMinVer = $container->get('settings')['postgresqlMinVer'];
+        $this->phpMinVer        = $container->get('settings')['phpMinVer'];
+
+        $base_version = $container->get('settings')['base_version'];
+        // Check for config file version mismatch
+        if (!isset($this->conf['version']) || $base_version > $this->conf['version']) {
+            die($this->lang['strbadconfig']);
+
+        }
+
+        // Check database support is properly compiled in
+        if (!function_exists('pg_connect')) {
+            die($this->lang['strnotloaded']);
+
+        }
+
+        // Check the version of PHP
+        if (version_compare(phpversion(), $this->phpMinVer, '<')) {
+            exit(sprintf('Version of PHP not supported. Please upgrade to version %s or later.', $this->phpMinVer));
+        }
+
+        if (count($this->conf['servers']) === 1) {
+            $info            = $this->conf['servers'][0];
+            $this->server_id = $info['host'] . ':' . $info['port'] . ':' . $info['sslmode'];
+        } else if (isset($_REQUEST['server'])) {
+            $this->server_id = $_REQUEST['server'];
+        } else if (isset($_SESSION['webdbLogin']) && count($_SESSION['webdbLogin']) > 0) {
+            $this->server_id = array_keys($_SESSION['webdbLogin'])[0];
+        }
+    }
+
+    /**
+     * Default Error Handler. This will be called with the following params
+     *
+     * @param $dbms        the RDBMS you are connecting to
+     * @param $fn        the name of the calling function (in uppercase)
+     * @param $errno        the native error number from the database
+     * @param $errmsg    the native error msg from the database
+     * @param $p1        $fn specific parameter - see below
+     * @param $P2        $fn specific parameter - see below
+     */
+    public static function adodb_throw($dbms, $fn, $errno, $errmsg, $p1, $p2, $thisConnection)
+    {
+
+        if (error_reporting() == 0) {
+            return;
+        }
+
+        $backtrace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 2);
+
+        $btarray0 = ([
+            'class'    => $backtrace[1]['class'],
+            'type'     => $backtrace[1]['type'],
+            'function' => $backtrace[1]['function'],
+            'spacer'   => ' ',
+            'line'     => $backtrace[0]['line'],
+        ]);
+
+        $errmsg = htmlspecialchars($errmsg);
+        $p1     = htmlspecialchars($p1);
+        $p2     = htmlspecialchars($p2);
+        switch ($fn) {
+            case 'EXECUTE':
+                $sql         = $p1;
+                $inputparams = $p2;
+
+                /*$s = "<p><b>{$lang['strsqlerror']}</b><br />" . $misc->printVal($errmsg, 'errormsg') . "</p> <p><b>{$lang['strinstatement']}</b><br />" . $misc->printVal($sql). "</p>    ";*/
+
+                $s = "<p><b>strsqlerror</b><br />" . $errmsg . "</p> <p><b>SQL:</b><br />" . $sql . "</p>	";
+
+                echo '<table class="error" cellpadding="5"><tr><td>' . $s . '</td></tr></table><br />' . "\n";
+
+                break;
+
+            case 'PCONNECT':
+            case 'CONNECT':
+                // do nothing;
+                break;
+            default:
+                $s = "$dbms error: [$errno: $errmsg] in $fn($p1, $p2)\n";
+                echo "<table class=\"error\" cellpadding=\"5\"><tr><td>{$s}</td></tr></table><br />\n";
+                break;
+        }
+
+        $tag = implode('', $btarray0);
+
+        \PC::debug(['errno' => $errno, 'fn' => $fn, 'errmsg' => $errmsg], $tag);
+
+        throw new \PHPPgAdmin\ADODB_Exception($dbms, $fn, $errno, $errmsg, $p1, $p2, $thisConnection);
+    }
+
+    public function getContainer()
+    {
+        return $this->container;
+    }
+
+    /**
+     * sets $_no_bottom_link boolean value
+     * @param boolean $flag [description]
+     */
+    public function setNoBottomLink($flag)
+    {
+        $this->_no_bottom_link = boolval($flag);
+        return $this;
+    }
+
+    /**
+     * sets $_no_db_connection boolean value, allows to render scripts that do not need an active session
+     * @param boolean $flag [description]
+     */
+    public function setNoDBConnection($flag)
+    {
+        $this->_no_db_connection = boolval($flag);
+        return $this;
+    }
+
+    public function setNoOutput($flag)
+    {
+        $this->_no_output = boolval($flag);
+        return $this;
+    }
+
+    public function getNoDBConnection()
+    {
+        return $this->_no_db_connection;
+    }
+
+    /**
+     * Creates a database accessor
+     */
+    public function getDatabaseAccessor($database = '', $server_id = null)
+    {
+        $lang = $this->lang;
+
+        if ($server_id !== null) {
+            $this->server_id = $server_id;
+        }
+
+        $server_info = $this->getServerInfo($this->server_id);
+
+        if ($this->_no_db_connection || !isset($server_info['username'])) {
+            return null;
+        }
+
+        if ($this->data === null) {
+            $_connection = $this->getConnection($database, $this->server_id);
+
+            //$this->prtrace('_connection', $_connection);
+            if (!$_connection) {
+                die($lang['strloginfailed']);
+            }
+            // Get the name of the database driver we need to use.
+            // The description of the server is returned in $platform.
+            $_type = $_connection->getDriver($platform);
+
+            $this->prtrace(['type' => $_type, 'platform' => $platform, 'pgVersion' => $_connection->conn->pgVersion]);
+
+            if ($_type === null) {
+                die(sprintf($lang['strpostgresqlversionnotsupported'], $this->postgresqlMinVer));
+            }
+            $_type = '\PHPPgAdmin\Database\\' . $_type;
+
+            $this->setServerInfo('platform', $platform, $this->server_id);
+            $this->setServerInfo('pgVersion', $_connection->conn->pgVersion, $this->server_id);
+
+            // Create a database wrapper class for easy manipulation of the
+            // connection.
+
+            $this->data              = new $_type($_connection->conn, $this->conf);
+            $this->data->platform    = $_connection->platform;
+            $this->data->server_info = $server_info;
+            $this->data->conf        = $this->conf;
+            $this->data->lang        = $this->lang;
+
+            /* we work on UTF-8 only encoding */
+            $this->data->execute("SET client_encoding TO 'UTF-8'");
+
+            if ($this->data->hasByteaHexDefault()) {
+                $this->data->execute("SET bytea_output TO escape");
+            }
+
+        }
+
+        if ($this->_no_db_connection === false && $this->getDatabase() !== null && isset($_REQUEST['schema'])) {
+            $status = $this->data->setSchema($_REQUEST['schema']);
+
+            if ($status != 0) {
+                \Kint::dump($status);
+                echo $this->lang['strbadschema'];
+                exit;
+            }
+        }
+
+        return $this->data;
+    }
+
+    public function getConnection($database = '', $server_id = null)
+    {
+        $lang = $this->lang;
+
+        if ($this->_connection === null) {
+            if ($server_id !== null) {
+                $this->server_id = $server_id;
+            }
+            $server_info     = $this->getServerInfo($this->server_id);
+            $database_to_use = $this->getDatabase($database);
+
+            // Perform extra security checks if this config option is set
+            if ($this->conf['extra_login_security']) {
+                // Disallowed logins if extra_login_security is enabled.
+                // These must be lowercase.
+                $bad_usernames = [
+                    'pgsql'         => 'pgsql',
+                    'postgres'      => 'postgres',
+                    'root'          => 'root',
+                    'administrator' => 'administrator',
+                ];
+
+                if (isset($server_info['username']) && array_key_exists(strtolower($server_info['username']), $bad_usernames)) {
+                    unset($_SESSION['webdbLogin'][$this->server_id]);
+                    $msg = $lang['strlogindisallowed'];
+                    $this->prtrace('msg', $msg);
+                    $login_controller = new LoginController($this->container);
+                    return $login_controller->render();
+                }
+
+                if (!isset($server_info['password']) || $server_info['password'] == '') {
+                    unset($_SESSION['webdbLogin'][$this->server_id]);
+                    $msg = $lang['strlogindisallowed'];
+                    $this->prtrace('msg', $msg);
+                    $login_controller = new LoginController($this->container);
+                    return $login_controller->render();
+                }
+            }
+            try {
+
+                // Create the connection object and make the connection
+                $this->_connection = new \PHPPgAdmin\Database\Connection(
+                    $server_info['host'],
+                    $server_info['port'],
+                    $server_info['sslmode'],
+                    $server_info['username'],
+                    $server_info['password'],
+                    $database_to_use
+                );
+
+            } catch (\PHPPgAdmin\ADODB_Exception $e) {
+                unset($_SESSION['webdbLogin'][$this->server_id]);
+                $msg              = $lang['strloginfailed'];
+                $login_controller = new LoginController($this->container);
+                return $login_controller->render();
+            }
+
+        }
+        return $this->_connection;
+    }
+
+    public function getDatabase($database = '')
+    {
+
+        if ($this->server_id === null && !isset($_REQUEST['database'])) {
+            return null;
+        }
+
+        $server_info = $this->getServerInfo($this->server_id);
+
+        if ($this->server_id !== null && isset($server_info['useonlydefaultdb']) && $server_info['useonlydefaultdb'] === true) {
+            $this->database = $server_info['defaultdb'];
+        } else if ($database !== '') {
+            $this->database = $database;
+        } else if (isset($_REQUEST['database'])) {
+            // Connect to the current database
+            $this->database = $_REQUEST['database'];
+        } else {
+            // or if one is not specified then connect to the default database.
+            $this->database = $server_info['defaultdb'];
+        }
+
+        return $this->database;
+
+    }
+
+    /**
+     * [setReloadBrowser description]
+     * @param boolean $flag sets internal $_reload_browser var which will be passed to the footer methods
+     */
+    public function setReloadBrowser($flag)
+    {
+        $this->_reload_browser = boolval($flag);
+        return $this;
+    }
+
+    /**
+     * [setReloadBrowser description]
+     * @param boolean $flag sets internal $_reload_drop_database var which will be passed to the footer methods
+     */
+    public function setReloadDropDatabase($flag)
+    {
+        $this->_reload_drop_database = boolval($flag);
+        return $this;
+    }
+
+    public static function _cmp_desc($a, $b)
+    {
+        return strcmp($a['desc'], $b['desc']);
+    }
+
+    /**
+     * Checks if dumps are properly set up
+     * @param $all (optional) True to check pg_dumpall, false to just check pg_dump
+     * @return True, dumps are set up, false otherwise
+     */
+    public function isDumpEnabled($all = false)
+    {
+        $info = $this->getServerInfo();
+
+        return !empty($info[$all ? 'pg_dumpall_path' : 'pg_dump_path']);
+    }
+
+    public function setThemeConf($theme_conf)
+    {
+
+        $this->conf['theme'] = $theme_conf;
+        //\PC::debug(['theme_conf' => $theme_conf, 'this->theme' => $this->conf['theme']], 'setThemeConf');
+        $this->view->offsetSet('theme', $this->conf['theme']);
+        return $this;
+    }
+
+    public function getConf()
+    {
+        return $this->conf;
+    }
+
+    /**
+     * Sets the href tracking variable
+     */
+    public function setHREF()
+    {
+        $this->href = $this->getHREF();
+        //\PC::debug($this->href, 'Misc::href');
+        return $this;
+
+    }
+
+    /**
+     * Get a href query string, excluding objects below the given object type (inclusive)
+     */
+    public function getHREF($exclude_from = null)
+    {
+        $href = [];
+        if (isset($_REQUEST['server']) && $exclude_from != 'server') {
+            $href[] = 'server=' . urlencode($_REQUEST['server']);
+        }
+        if (isset($_REQUEST['database']) && $exclude_from != 'database') {
+            $href[] = 'database=' . urlencode($_REQUEST['database']);
+        }
+        if (isset($_REQUEST['schema']) && $exclude_from != 'schema') {
+            $href[] = 'schema=' . urlencode($_REQUEST['schema']);
+        }
+
+        return htmlentities(implode('&', $href));
+    }
+
+    public function getSubjectParams($subject)
+    {
+        $plugin_manager = $this->plugin_manager;
+
+        $vars = [];
+
+        switch ($subject) {
+            case 'root':
+                $vars = [
+                    'params' => [
+                        'subject' => 'root',
+                    ],
+                ];
+                break;
+            case 'server':
+                $vars = ['params' => [
+                    'server'  => $_REQUEST['server'],
+                    'subject' => 'server',
+                ]];
+                break;
+            case 'role':
+                $vars = ['params' => [
+                    'server'   => $_REQUEST['server'],
+                    'subject'  => 'role',
+                    'action'   => 'properties',
+                    'rolename' => $_REQUEST['rolename'],
+                ]];
+                break;
+            case 'database':
+                $vars = ['params' => [
+                    'server'   => $_REQUEST['server'],
+                    'subject'  => 'database',
+                    'database' => $_REQUEST['database'],
+                ]];
+                break;
+            case 'schema':
+                $vars = ['params' => [
+                    'server'   => $_REQUEST['server'],
+                    'subject'  => 'schema',
+                    'database' => $_REQUEST['database'],
+                    'schema'   => $_REQUEST['schema'],
+                ]];
+                break;
+            case 'table':
+                $vars = ['params' => [
+                    'server'   => $_REQUEST['server'],
+                    'subject'  => 'table',
+                    'database' => $_REQUEST['database'],
+                    'schema'   => $_REQUEST['schema'],
+                    'table'    => $_REQUEST['table'],
+                ]];
+                break;
+            case 'selectrows':
+                $vars = [
+                    'url'    => 'tables.php',
+                    'params' => [
+                        'server'   => $_REQUEST['server'],
+                        'subject'  => 'table',
+                        'database' => $_REQUEST['database'],
+                        'schema'   => $_REQUEST['schema'],
+                        'table'    => $_REQUEST['table'],
+                        'action'   => 'confselectrows',
+                    ]];
+                break;
+            case 'view':
+                $vars = ['params' => [
+                    'server'   => $_REQUEST['server'],
+                    'subject'  => 'view',
+                    'database' => $_REQUEST['database'],
+                    'schema'   => $_REQUEST['schema'],
+                    'view'     => $_REQUEST['view'],
+                ]];
+                break;
+            case 'matview':
+                $vars = ['params' => [
+                    'server'   => $_REQUEST['server'],
+                    'subject'  => 'matview',
+                    'database' => $_REQUEST['database'],
+                    'schema'   => $_REQUEST['schema'],
+                    'matview'  => $_REQUEST['matview'],
+                ]];
+                break;
+
+            case 'fulltext':
+            case 'ftscfg':
+                $vars = ['params' => [
+                    'server'   => $_REQUEST['server'],
+                    'subject'  => 'fulltext',
+                    'database' => $_REQUEST['database'],
+                    'schema'   => $_REQUEST['schema'],
+                    'action'   => 'viewconfig',
+                    'ftscfg'   => $_REQUEST['ftscfg'],
+                ]];
+                break;
+            case 'function':
+                $vars = ['params' => [
+                    'server'       => $_REQUEST['server'],
+                    'subject'      => 'function',
+                    'database'     => $_REQUEST['database'],
+                    'schema'       => $_REQUEST['schema'],
+                    'function'     => $_REQUEST['function'],
+                    'function_oid' => $_REQUEST['function_oid'],
+                ]];
+                break;
+            case 'aggregate':
+                $vars = ['params' => [
+                    'server'   => $_REQUEST['server'],
+                    'subject'  => 'aggregate',
+                    'action'   => 'properties',
+                    'database' => $_REQUEST['database'],
+                    'schema'   => $_REQUEST['schema'],
+                    'aggrname' => $_REQUEST['aggrname'],
+                    'aggrtype' => $_REQUEST['aggrtype'],
+                ]];
+                break;
+            case 'column':
+                if (isset($_REQUEST['table'])) {
+                    $vars = ['params' => [
+                        'server'   => $_REQUEST['server'],
+                        'subject'  => 'column',
+                        'database' => $_REQUEST['database'],
+                        'schema'   => $_REQUEST['schema'],
+                        'table'    => $_REQUEST['table'],
+                        'column'   => $_REQUEST['column'],
+                    ]];
+                } else {
+                    $vars = ['params' => [
+                        'server'   => $_REQUEST['server'],
+                        'subject'  => 'column',
+                        'database' => $_REQUEST['database'],
+                        'schema'   => $_REQUEST['schema'],
+                        'view'     => $_REQUEST['view'],
+                        'column'   => $_REQUEST['column'],
+                    ]];
+                }
+
+                break;
+            case 'plugin':
+                $vars = [
+                    'url'    => 'plugin.php',
+                    'params' => [
+                        'server'  => $_REQUEST['server'],
+                        'subject' => 'plugin',
+                        'plugin'  => $_REQUEST['plugin'],
+                    ]];
+
+                if (!is_null($plugin_manager->getPlugin($_REQUEST['plugin']))) {
+                    $vars['params'] = array_merge($vars['params'], $plugin_manager->getPlugin($_REQUEST['plugin'])->get_subject_params());
+                }
+
+                break;
+            default:
+                return false;
+        }
+
+        if (!isset($vars['url'])) {
+            $vars['url'] = '/redirect';
+        }
+        if ($vars['url'] == '/redirect' && isset($vars['params']['subject'])) {
+            $vars['url'] = '/redirect/' . $vars['params']['subject'];
+            unset($vars['params']['subject']);
+        }
+
+        return $vars;
+    }
+
+    /**
+     * Sets the form tracking variable
+     */
+    public function setForm()
+    {
+        $form = [];
+        if (isset($_REQUEST['server'])) {
+            $form[] = '<input type="hidden" name="server" value="' . htmlspecialchars($_REQUEST['server']) . '" />';
+        }
+        if (isset($_REQUEST['database'])) {
+            $form[] = '<input type="hidden" name="database" value="' . htmlspecialchars($_REQUEST['database']) . '" />';
+        }
+
+        if (isset($_REQUEST['schema'])) {
+            $form[] = '<input type="hidden" name="schema" value="' . htmlspecialchars($_REQUEST['schema']) . '" />';
+        }
+        $this->form = implode("\n", $form);
+        return $this->form;
+
+        //\PC::debug($this->form, 'Misc::form');
+    }
+
+    /**
+     * Render a value into HTML using formatting rules specified
+     * by a type name and parameters.
+     *
+     * @param $str The string to change
+     *
+     * @param $type Field type (optional), this may be an internal PostgreSQL type, or:
+     *            yesno    - same as bool, but renders as 'Yes' or 'No'.
+     *            pre      - render in a <pre> block.
+     *            nbsp     - replace all spaces with &nbsp;'s
+     *            verbatim - render exactly as supplied, no escaping what-so-ever.
+     *            callback - render using a callback function supplied in the 'function' param.
+     *
+     * @param $params Type parameters (optional), known parameters:
+     *            null     - string to display if $str is null, or set to TRUE to use a default 'NULL' string,
+     *                       otherwise nothing is rendered.
+     *            clip     - if true, clip the value to a fixed length, and append an ellipsis...
+     *            cliplen  - the maximum length when clip is enabled (defaults to $conf['max_chars'])
+     *            ellipsis - the string to append to a clipped value (defaults to $lang['strellipsis'])
+     *            tag      - an HTML element name to surround the value.
+     *            class    - a class attribute to apply to any surrounding HTML element.
+     *            align    - an align attribute ('left','right','center' etc.)
+     *            true     - (type='bool') the representation of true.
+     *            false    - (type='bool') the representation of false.
+     *            function - (type='callback') a function name, accepts args ($str, $params) and returns a rendering.
+     *            lineno   - prefix each line with a line number.
+     *            map      - an associative array.
+     *
+     * @return The HTML rendered value
+     */
+    public function printVal($str, $type = null, $params = [])
+    {
+        $lang = $this->lang;
+        $data = $this->data;
+
+        // Shortcircuit for a NULL value
+        if (is_null($str)) {
+            return isset($params['null'])
+            ? ($params['null'] === true ? '<i>NULL</i>' : $params['null'])
+            : '';
+        }
+
+        if (isset($params['map']) && isset($params['map'][$str])) {
+            $str = $params['map'][$str];
+        }
+
+        // Clip the value if the 'clip' parameter is true.
+        if (isset($params['clip']) && $params['clip'] === true) {
+            $maxlen   = isset($params['cliplen']) && is_integer($params['cliplen']) ? $params['cliplen'] : $this->conf['max_chars'];
+            $ellipsis = isset($params['ellipsis']) ? $params['ellipsis'] : $lang['strellipsis'];
+            if (strlen($str) > $maxlen) {
+                $str = substr($str, 0, $maxlen - 1) . $ellipsis;
+            }
+        }
+
+        $out = '';
+
+        switch ($type) {
+            case 'int2':
+            case 'int4':
+            case 'int8':
+            case 'float4':
+            case 'float8':
+            case 'money':
+            case 'numeric':
+            case 'oid':
+            case 'xid':
+            case 'cid':
+            case 'tid':
+                $align = 'right';
+                $out   = nl2br(htmlspecialchars($str));
+                break;
+            case 'yesno':
+                if (!isset($params['true'])) {
+                    $params['true'] = $lang['stryes'];
+                }
+
+                if (!isset($params['false'])) {
+                    $params['false'] = $lang['strno'];
+                }
+
+            // No break - fall through to boolean case.
+            case 'bool':
+            case 'boolean':
+                if (is_bool($str)) {
+                    $str = $str ? 't' : 'f';
+                }
+
+                switch ($str) {
+                    case 't':
+                        $out   = (isset($params['true']) ? $params['true'] : $lang['strtrue']);
+                        $align = 'center';
+                        break;
+                    case 'f':
+                        $out   = (isset($params['false']) ? $params['false'] : $lang['strfalse']);
+                        $align = 'center';
+                        break;
+                    default:
+                        $out = htmlspecialchars($str);
+                }
+                break;
+            case 'bytea':
+                $tag   = 'div';
+                $class = 'pre';
+                $out   = $data->escapeBytea($str);
+                break;
+            case 'errormsg':
+                $tag   = 'pre';
+                $class = 'error';
+                $out   = htmlspecialchars($str);
+                break;
+            case 'pre':
+                $tag = 'pre';
+                $out = htmlspecialchars($str);
+                break;
+            case 'prenoescape':
+                $tag = 'pre';
+                $out = $str;
+                break;
+            case 'nbsp':
+                $out = nl2br(str_replace(' ', '&nbsp;', htmlspecialchars($str)));
+                break;
+            case 'verbatim':
+                $out = $str;
+                break;
+            case 'callback':
+                $out = $params['function']($str, $params);
+                break;
+            case 'prettysize':
+                if ($str == -1) {
+                    $out = $lang['strnoaccess'];
+                } else {
+                    $limit = 10 * 1024;
+                    $mult  = 1;
+                    if ($str < $limit * $mult) {
+                        $out = $str . ' ' . $lang['strbytes'];
+                    } else {
+                        $mult *= 1024;
+                        if ($str < $limit * $mult) {
+                            $out = floor(($str + $mult / 2) / $mult) . ' ' . $lang['strkb'];
+                        } else {
+                            $mult *= 1024;
+                            if ($str < $limit * $mult) {
+                                $out = floor(($str + $mult / 2) / $mult) . ' ' . $lang['strmb'];
+                            } else {
+                                $mult *= 1024;
+                                if ($str < $limit * $mult) {
+                                    $out = floor(($str + $mult / 2) / $mult) . ' ' . $lang['strgb'];
+                                } else {
+                                    $mult *= 1024;
+                                    if ($str < $limit * $mult) {
+                                        $out = floor(($str + $mult / 2) / $mult) . ' ' . $lang['strtb'];
+                                    }
+
+                                }
+                            }
+                        }
+                    }
+                }
+                break;
+            default:
+                // If the string contains at least one instance of >1 space in a row, a tab
+                // character, a space at the start of a line, or a space at the start of
+                // the whole string then render within a pre-formatted element (<pre>).
+                if (preg_match('/(^ |  |\t|\n )/m', $str)) {
+                    $tag   = 'pre';
+                    $class = 'data';
+                    $out   = htmlspecialchars($str);
+                } else {
+                    $out = nl2br(htmlspecialchars($str));
+                }
+        }
+
+        if (isset($params['class'])) {
+            $class = $params['class'];
+        }
+
+        if (isset($params['align'])) {
+            $align = $params['align'];
+        }
+
+        if (!isset($tag) && (isset($class) || isset($align))) {
+            $tag = 'div';
+        }
+
+        if (isset($tag)) {
+            $alignattr = isset($align) ? " style=\"text-align: {$align}\"" : '';
+            $classattr = isset($class) ? " class=\"{$class}\"" : '';
+            $out       = "<{$tag}{$alignattr}{$classattr}>{$out}</{$tag}>";
+        }
+
+        // Add line numbers if 'lineno' param is true
+        if (isset($params['lineno']) && $params['lineno'] === true) {
+            $lines = explode("\n", $str);
+            $num   = count($lines);
+            if ($num > 0) {
+                $temp = "<table>\n<tr><td class=\"{$class}\" style=\"vertical-align: top; padding-right: 10px;\"><pre class=\"{$class}\">";
+                for ($i = 1; $i <= $num; $i++) {
+                    $temp .= $i . "\n";
+                }
+                $temp .= "</pre></td><td class=\"{$class}\" style=\"vertical-align: top;\">{$out}</td></tr></table>\n";
+                $out = $temp;
+            }
+            unset($lines);
+        }
+
+        return $out;
+    }
+
+    /**
+     * A function to recursively strip slashes.  Used to
+     * enforce magic_quotes_gpc being off.
+     * @param &var The variable to strip
+     */
+    public function stripVar(&$var)
+    {
+        if (is_array($var)) {
+            foreach ($var as $k => $v) {
+                $this->stripVar($var[$k]);
+
+                /* magic_quotes_gpc escape keys as well ...*/
+                if (is_string($k)) {
+                    $ek = stripslashes($k);
+                    if ($ek !== $k) {
+                        $var[$ek] = $var[$k];
+                        unset($var[$k]);
+                    }
+                }
+            }
+        } else {
+            $var = stripslashes($var);
+        }
+
+    }
+
+    /**
+     * Print out a message
+     * @param $msg The message to print
+     */
+    public function printMsg($msg, $do_print = true)
+    {
+        $html = '';
+        $msg  = htmlspecialchars($msg);
+        if ($msg != '') {
+            $html .= "<p class=\"message\">{$msg}</p>\n";
+        }
+        if ($do_print) {
+            echo $html;
+        } else {
+            return $html;
+        }
+
+    }
+
+    /**
+     * Retrieve the tab info for a specific tab bar.
+     * @param $section The name of the tab bar.
+     */
+    public function getNavTabs($section)
+    {
+
+        $data           = $this->data;
+        $lang           = $this->lang;
+        $plugin_manager = $this->plugin_manager;
+
+        $hide_advanced = ($this->conf['show_advanced'] === false);
+        $tabs          = [];
+
+        switch ($section) {
+            case 'root':
+                $tabs = [
+                    'intro'   => [
+                        'title' => $lang['strintroduction'],
+                        'url'   => "intro.php",
+                        'icon'  => 'Introduction',
+                    ],
+                    'servers' => [
+                        'title' => $lang['strservers'],
+                        'url'   => "servers.php",
+                        'icon'  => 'Servers',
+                    ],
+                ];
+                break;
+
+            case 'server':
+                $hide_users = true;
+                if ($data) {
+                    $hide_users = !$data->isSuperUser();
+                }
+
+                $tabs = [
+                    'databases' => [
+                        'title'   => $lang['strdatabases'],
+                        'url'     => 'all_db.php',
+                        'urlvars' => ['subject' => 'server'],
+                        'help'    => 'pg.database',
+                        'icon'    => 'Databases',
+                    ],
+                ];
+                if ($data && $data->hasRoles()) {
+                    $tabs = array_merge($tabs, [
+                        'roles' => [
+                            'title'   => $lang['strroles'],
+                            'url'     => 'roles.php',
+                            'urlvars' => ['subject' => 'server'],
+                            'hide'    => $hide_users,
+                            'help'    => 'pg.role',
+                            'icon'    => 'Roles',
+                        ],
+                    ]);
+                } else {
+                    $tabs = array_merge($tabs, [
+                        'users'  => [
+                            'title'   => $lang['strusers'],
+                            'url'     => 'users.php',
+                            'urlvars' => ['subject' => 'server'],
+                            'hide'    => $hide_users,
+                            'help'    => 'pg.user',
+                            'icon'    => 'Users',
+                        ],
+                        'groups' => [
+                            'title'   => $lang['strgroups'],
+                            'url'     => 'groups.php',
+                            'urlvars' => ['subject' => 'server'],
+                            'hide'    => $hide_users,
+                            'help'    => 'pg.group',
+                            'icon'    => 'UserGroups',
+                        ],
+                    ]);
+                }
+
+                $tabs = array_merge($tabs, [
+                    'account'     => [
+                        'title'   => $lang['straccount'],
+                        'url'     => ($data && $data->hasRoles()) ? 'roles.php' : 'users.php',
+                        'urlvars' => ['subject' => 'server', 'action' => 'account'],
+                        'hide'    => !$hide_users,
+                        'help'    => 'pg.role',
+                        'icon'    => 'User',
+                    ],
+                    'tablespaces' => [
+                        'title'   => $lang['strtablespaces'],
+                        'url'     => 'tablespaces.php',
+                        'urlvars' => ['subject' => 'server'],
+                        'hide'    => (!$data || !$data->hasTablespaces()),
+                        'help'    => 'pg.tablespace',
+                        'icon'    => 'Tablespaces',
+                    ],
+                    'export'      => [
+                        'title'   => $lang['strexport'],
+                        'url'     => 'all_db.php',
+                        'urlvars' => ['subject' => 'server', 'action' => 'export'],
+                        'hide'    => (!$this->isDumpEnabled()),
+                        'icon'    => 'Export',
+                    ],
+                ]);
+                break;
+            case 'database':
+                $tabs = [
+                    'schemas'    => [
+                        'title'   => $lang['strschemas'],
+                        'url'     => 'schemas.php',
+                        'urlvars' => ['subject' => 'database'],
+                        'help'    => 'pg.schema',
+                        'icon'    => 'Schemas',
+                    ],
+                    'sql'        => [
+                        'title'   => $lang['strsql'],
+                        'url'     => 'database.php',
+                        'urlvars' => ['subject' => 'database', 'action' => 'sql', 'new' => 1],
+                        'help'    => 'pg.sql',
+                        'tree'    => false,
+                        'icon'    => 'SqlEditor',
+                    ],
+                    'find'       => [
+                        'title'   => $lang['strfind'],
+                        'url'     => 'database.php',
+                        'urlvars' => ['subject' => 'database', 'action' => 'find'],
+                        'tree'    => false,
+                        'icon'    => 'Search',
+                    ],
+                    'variables'  => [
+                        'title'   => $lang['strvariables'],
+                        'url'     => 'database.php',
+                        'urlvars' => ['subject' => 'database', 'action' => 'variables'],
+                        'help'    => 'pg.variable',
+                        'tree'    => false,
+                        'icon'    => 'Variables',
+                    ],
+                    'processes'  => [
+                        'title'   => $lang['strprocesses'],
+                        'url'     => 'database.php',
+                        'urlvars' => ['subject' => 'database', 'action' => 'processes'],
+                        'help'    => 'pg.process',
+                        'tree'    => false,
+                        'icon'    => 'Processes',
+                    ],
+                    'locks'      => [
+                        'title'   => $lang['strlocks'],
+                        'url'     => 'database.php',
+                        'urlvars' => ['subject' => 'database', 'action' => 'locks'],
+                        'help'    => 'pg.locks',
+                        'tree'    => false,
+                        'icon'    => 'Key',
+                    ],
+                    'admin'      => [
+                        'title'   => $lang['stradmin'],
+                        'url'     => 'database.php',
+                        'urlvars' => ['subject' => 'database', 'action' => 'admin'],
+                        'tree'    => false,
+                        'icon'    => 'Admin',
+                    ],
+                    'privileges' => [
+                        'title'   => $lang['strprivileges'],
+                        'url'     => 'privileges.php',
+                        'urlvars' => ['subject' => 'database'],
+                        'hide'    => (!isset($data->privlist['database'])),
+                        'help'    => 'pg.privilege',
+                        'tree'    => false,
+                        'icon'    => 'Privileges',
+                    ],
+                    'languages'  => [
+                        'title'   => $lang['strlanguages'],
+                        'url'     => 'languages.php',
+                        'urlvars' => ['subject' => 'database'],
+                        'hide'    => $hide_advanced,
+                        'help'    => 'pg.language',
+                        'icon'    => 'Languages',
+                    ],
+                    'casts'      => [
+                        'title'   => $lang['strcasts'],
+                        'url'     => 'casts.php',
+                        'urlvars' => ['subject' => 'database'],
+                        'hide'    => ($hide_advanced),
+                        'help'    => 'pg.cast',
+                        'icon'    => 'Casts',
+                    ],
+                    'export'     => [
+                        'title'   => $lang['strexport'],
+                        'url'     => 'database.php',
+                        'urlvars' => ['subject' => 'database', 'action' => 'export'],
+                        'hide'    => (!$this->isDumpEnabled()),
+                        'tree'    => false,
+                        'icon'    => 'Export',
+                    ],
+                ];
+                break;
+
+            case 'schema':
+                $tabs = [
+                    'tables'      => [
+                        'title'   => $lang['strtables'],
+                        'url'     => 'tables.php',
+                        'urlvars' => ['subject' => 'schema'],
+                        'help'    => 'pg.table',
+                        'icon'    => 'Tables',
+                    ],
+                    'views'       => [
+                        'title'   => $lang['strviews'],
+                        'url'     => 'views.php',
+                        'urlvars' => ['subject' => 'schema'],
+                        'help'    => 'pg.view',
+                        'icon'    => 'Views',
+                    ],
+                    'matviews'    => [
+                        'title'   => 'M ' . $lang['strviews'],
+                        'url'     => 'materialized_views.php',
+                        'urlvars' => ['subject' => 'schema'],
+                        'help'    => 'pg.matview',
+                        'icon'    => 'MViews',
+                    ],
+                    'sequences'   => [
+                        'title'   => $lang['strsequences'],
+                        'url'     => 'sequences.php',
+                        'urlvars' => ['subject' => 'schema'],
+                        'help'    => 'pg.sequence',
+                        'icon'    => 'Sequences',
+                    ],
+                    'functions'   => [
+                        'title'   => $lang['strfunctions'],
+                        'url'     => 'functions.php',
+                        'urlvars' => ['subject' => 'schema'],
+                        'help'    => 'pg.function',
+                        'icon'    => 'Functions',
+                    ],
+                    'fulltext'    => [
+                        'title'   => $lang['strfulltext'],
+                        'url'     => 'fulltext.php',
+                        'urlvars' => ['subject' => 'schema'],
+                        'help'    => 'pg.fts',
+                        'tree'    => true,
+                        'icon'    => 'Fts',
+                    ],
+                    'domains'     => [
+                        'title'   => $lang['strdomains'],
+                        'url'     => 'domains.php',
+                        'urlvars' => ['subject' => 'schema'],
+                        'help'    => 'pg.domain',
+                        'icon'    => 'Domains',
+                    ],
+                    'aggregates'  => [
+                        'title'   => $lang['straggregates'],
+                        'url'     => 'aggregates.php',
+                        'urlvars' => ['subject' => 'schema'],
+                        'hide'    => $hide_advanced,
+                        'help'    => 'pg.aggregate',
+                        'icon'    => 'Aggregates',
+                    ],
+                    'types'       => [
+                        'title'   => $lang['strtypes'],
+                        'url'     => 'types.php',
+                        'urlvars' => ['subject' => 'schema'],
+                        'hide'    => $hide_advanced,
+                        'help'    => 'pg.type',
+                        'icon'    => 'Types',
+                    ],
+                    'operators'   => [
+                        'title'   => $lang['stroperators'],
+                        'url'     => 'operators.php',
+                        'urlvars' => ['subject' => 'schema'],
+                        'hide'    => $hide_advanced,
+                        'help'    => 'pg.operator',
+                        'icon'    => 'Operators',
+                    ],
+                    'opclasses'   => [
+                        'title'   => $lang['stropclasses'],
+                        'url'     => 'opclasses.php',
+                        'urlvars' => ['subject' => 'schema'],
+                        'hide'    => $hide_advanced,
+                        'help'    => 'pg.opclass',
+                        'icon'    => 'OperatorClasses',
+                    ],
+                    'conversions' => [
+                        'title'   => $lang['strconversions'],
+                        'url'     => 'conversions.php',
+                        'urlvars' => ['subject' => 'schema'],
+                        'hide'    => $hide_advanced,
+                        'help'    => 'pg.conversion',
+                        'icon'    => 'Conversions',
+                    ],
+                    'privileges'  => [
+                        'title'   => $lang['strprivileges'],
+                        'url'     => 'privileges.php',
+                        'urlvars' => ['subject' => 'schema'],
+                        'help'    => 'pg.privilege',
+                        'tree'    => false,
+                        'icon'    => 'Privileges',
+                    ],
+                    'export'      => [
+                        'title'   => $lang['strexport'],
+                        'url'     => 'schemas.php',
+                        'urlvars' => ['subject' => 'schema', 'action' => 'export'],
+                        'hide'    => (!$this->isDumpEnabled()),
+                        'tree'    => false,
+                        'icon'    => 'Export',
+                    ],
+                ];
+                if (!$data->hasFTS()) {
+                    unset($tabs['fulltext']);
+                }
+
+                break;
+
+            case 'table':
+                $tabs = [
+                    'columns'     => [
+                        'title'   => $lang['strcolumns'],
+                        'url'     => 'tblproperties.php',
+                        'urlvars' => ['subject' => 'table', 'table' => Decorator::field('table')],
+                        'icon'    => 'Columns',
+                        'branch'  => true,
+                    ],
+                    'browse'      => [
+                        'title'   => $lang['strbrowse'],
+                        'icon'    => 'Columns',
+                        'url'     => 'display.php',
+                        'urlvars' => ['subject' => 'table', 'table' => Decorator::field('table')],
+                        'return'  => 'table',
+                        'branch'  => true,
+                    ],
+                    'select'      => [
+                        'title'   => $lang['strselect'],
+                        'icon'    => 'Search',
+                        'url'     => 'tables.php',
+                        'urlvars' => ['subject' => 'table', 'table' => Decorator::field('table'), 'action' => 'confselectrows'],
+                        'help'    => 'pg.sql.select',
+                    ],
+                    'insert'      => [
+                        'title'   => $lang['strinsert'],
+                        'url'     => 'tables.php',
+                        'urlvars' => [
+                            'action' => 'confinsertrow',
+                            'table'  => Decorator::field('table'),
+                        ],
+                        'help'    => 'pg.sql.insert',
+                        'icon'    => 'Operator',
+                    ],
+                    'indexes'     => [
+                        'title'   => $lang['strindexes'],
+                        'url'     => 'indexes.php',
+                        'urlvars' => ['subject' => 'table', 'table' => Decorator::field('table')],
+                        'help'    => 'pg.index',
+                        'icon'    => 'Indexes',
+                        'branch'  => true,
+                    ],
+                    'constraints' => [
+                        'title'   => $lang['strconstraints'],
+                        'url'     => 'constraints.php',
+                        'urlvars' => ['subject' => 'table', 'table' => Decorator::field('table')],
+                        'help'    => 'pg.constraint',
+                        'icon'    => 'Constraints',
+                        'branch'  => true,
+                    ],
+                    'triggers'    => [
+                        'title'   => $lang['strtriggers'],
+                        'url'     => 'triggers.php',
+                        'urlvars' => ['subject' => 'table', 'table' => Decorator::field('table')],
+                        'help'    => 'pg.trigger',
+                        'icon'    => 'Triggers',
+                        'branch'  => true,
+                    ],
+                    'rules'       => [
+                        'title'   => $lang['strrules'],
+                        'url'     => 'rules.php',
+                        'urlvars' => ['subject' => 'table', 'table' => Decorator::field('table')],
+                        'help'    => 'pg.rule',
+                        'icon'    => 'Rules',
+                        'branch'  => true,
+                    ],
+                    'admin'       => [
+                        'title'   => $lang['stradmin'],
+                        'url'     => 'tables.php',
+                        'urlvars' => ['subject' => 'table', 'table' => Decorator::field('table'), 'action' => 'admin'],
+                        'icon'    => 'Admin',
+                    ],
+                    'info'        => [
+                        'title'   => $lang['strinfo'],
+                        'url'     => 'info.php',
+                        'urlvars' => ['subject' => 'table', 'table' => Decorator::field('table')],
+                        'icon'    => 'Statistics',
+                    ],
+                    'privileges'  => [
+                        'title'   => $lang['strprivileges'],
+                        'url'     => 'privileges.php',
+                        'urlvars' => ['subject' => 'table', 'table' => Decorator::field('table')],
+                        'help'    => 'pg.privilege',
+                        'icon'    => 'Privileges',
+                    ],
+                    'import'      => [
+                        'title'   => $lang['strimport'],
+                        'url'     => 'tblproperties.php',
+                        'urlvars' => ['subject' => 'table', 'table' => Decorator::field('table'), 'action' => 'import'],
+                        'icon'    => 'Import',
+                        'hide'    => false,
+                    ],
+                    'export'      => [
+                        'title'   => $lang['strexport'],
+                        'url'     => 'tblproperties.php',
+                        'urlvars' => ['subject' => 'table', 'table' => Decorator::field('table'), 'action' => 'export'],
+                        'icon'    => 'Export',
+                        'hide'    => false,
+                    ],
+                ];
+                break;
+
+            case 'view':
+                $tabs = [
+                    'columns'    => [
+                        'title'   => $lang['strcolumns'],
+                        'url'     => 'viewproperties.php',
+                        'urlvars' => ['subject' => 'view', 'view' => Decorator::field('view')],
+                        'icon'    => 'Columns',
+                        'branch'  => true,
+                    ],
+                    'browse'     => [
+                        'title'   => $lang['strbrowse'],
+                        'icon'    => 'Columns',
+                        'url'     => 'display.php',
+                        'urlvars' => [
+                            'action'  => 'confselectrows',
+                            'return'  => 'schema',
+                            'subject' => 'view',
+                            'view'    => Decorator::field('view'),
+                        ],
+                        'branch'  => true,
+                    ],
+                    'select'     => [
+                        'title'   => $lang['strselect'],
+                        'icon'    => 'Search',
+                        'url'     => 'views.php',
+                        'urlvars' => ['action' => 'confselectrows', 'view' => Decorator::field('view')],
+                        'help'    => 'pg.sql.select',
+                    ],
+                    'definition' => [
+                        'title'   => $lang['strdefinition'],
+                        'url'     => 'viewproperties.php',
+                        'urlvars' => ['subject' => 'view', 'view' => Decorator::field('view'), 'action' => 'definition'],
+                        'icon'    => 'Definition',
+                    ],
+                    'rules'      => [
+                        'title'   => $lang['strrules'],
+                        'url'     => 'rules.php',
+                        'urlvars' => ['subject' => 'view', 'view' => Decorator::field('view')],
+                        'help'    => 'pg.rule',
+                        'icon'    => 'Rules',
+                        'branch'  => true,
+                    ],
+                    'privileges' => [
+                        'title'   => $lang['strprivileges'],
+                        'url'     => 'privileges.php',
+                        'urlvars' => ['subject' => 'view', 'view' => Decorator::field('view')],
+                        'help'    => 'pg.privilege',
+                        'icon'    => 'Privileges',
+                    ],
+                    'export'     => [
+                        'title'   => $lang['strexport'],
+                        'url'     => 'viewproperties.php',
+                        'urlvars' => ['subject' => 'view', 'view' => Decorator::field('view'), 'action' => 'export'],
+                        'icon'    => 'Export',
+                        'hide'    => false,
+                    ],
+                ];
+                break;
+
+            case 'matview':
+                $tabs = [
+                    'columns'    => [
+                        'title'   => $lang['strcolumns'],
+                        'url'     => 'materializedviewproperties.php',
+                        'urlvars' => ['subject' => 'matview', 'matview' => Decorator::field('matview')],
+                        'icon'    => 'Columns',
+                        'branch'  => true,
+                    ],
+                    'browse'     => [
+                        'title'   => $lang['strbrowse'],
+                        'icon'    => 'Columns',
+                        'url'     => 'display.php',
+                        'urlvars' => [
+                            'action'  => 'confselectrows',
+                            'return'  => 'schema',
+                            'subject' => 'matview',
+                            'matview' => Decorator::field('matview'),
+                        ],
+                        'branch'  => true,
+                    ],
+                    'select'     => [
+                        'title'   => $lang['strselect'],
+                        'icon'    => 'Search',
+                        'url'     => 'materialized_views.php',
+                        'urlvars' => ['action' => 'confselectrows', 'matview' => Decorator::field('matview')],
+                        'help'    => 'pg.sql.select',
+                    ],
+                    'definition' => [
+                        'title'   => $lang['strdefinition'],
+                        'url'     => 'materializedviewproperties.php',
+                        'urlvars' => ['subject' => 'matview', 'matview' => Decorator::field('matview'), 'action' => 'definition'],
+                        'icon'    => 'Definition',
+                    ],
+                    'indexes'    => [
+                        'title'   => $lang['strindexes'],
+                        'url'     => 'indexes.php',
+                        'urlvars' => ['subject' => 'matview', 'matview' => Decorator::field('matview')],
+                        'help'    => 'pg.index',
+                        'icon'    => 'Indexes',
+                        'branch'  => true,
+                    ],
+                    /*'constraints' => [
+                    'title' => $lang['strconstraints'],
+                    'url' => 'constraints.php',
+                    'urlvars' => ['subject' => 'matview', 'matview' => Decorator::field('matview')],
+                    'help' => 'pg.constraint',
+                    'icon' => 'Constraints',
+                    'branch' => true,
+                    ],*/
+
+                    'rules'      => [
+                        'title'   => $lang['strrules'],
+                        'url'     => 'rules.php',
+                        'urlvars' => ['subject' => 'matview', 'matview' => Decorator::field('matview')],
+                        'help'    => 'pg.rule',
+                        'icon'    => 'Rules',
+                        'branch'  => true,
+                    ],
+                    'privileges' => [
+                        'title'   => $lang['strprivileges'],
+                        'url'     => 'privileges.php',
+                        'urlvars' => ['subject' => 'matview', 'matview' => Decorator::field('matview')],
+                        'help'    => 'pg.privilege',
+                        'icon'    => 'Privileges',
+                    ],
+                    'export'     => [
+                        'title'   => $lang['strexport'],
+                        'url'     => 'materializedviewproperties.php',
+                        'urlvars' => ['subject' => 'matview', 'matview' => Decorator::field('matview'), 'action' => 'export'],
+                        'icon'    => 'Export',
+                        'hide'    => false,
+                    ],
+                ];
+                break;
+
+            case 'function':
+                $tabs = [
+                    'definition' => [
+                        'title'   => $lang['strdefinition'],
+                        'url'     => 'functions.php',
+                        'urlvars' => [
+                            'subject'      => 'function',
+                            'function'     => Decorator::field('function'),
+                            'function_oid' => Decorator::field('function_oid'),
+                            'action'       => 'properties',
+                        ],
+                        'icon'    => 'Definition',
+                    ],
+                    'privileges' => [
+                        'title'   => $lang['strprivileges'],
+                        'url'     => 'privileges.php',
+                        'urlvars' => [
+                            'subject'      => 'function',
+                            'function'     => Decorator::field('function'),
+                            'function_oid' => Decorator::field('function_oid'),
+                        ],
+                        'icon'    => 'Privileges',
+                    ],
+                ];
+                break;
+
+            case 'aggregate':
+                $tabs = [
+                    'definition' => [
+                        'title'   => $lang['strdefinition'],
+                        'url'     => 'aggregates.php',
+                        'urlvars' => [
+                            'subject'  => 'aggregate',
+                            'aggrname' => Decorator::field('aggrname'),
+                            'aggrtype' => Decorator::field('aggrtype'),
+                            'action'   => 'properties',
+                        ],
+                        'icon'    => 'Definition',
+                    ],
+                ];
+                break;
+
+            case 'role':
+                $tabs = [
+                    'definition' => [
+                        'title'   => $lang['strdefinition'],
+                        'url'     => 'roles.php',
+                        'urlvars' => [
+                            'subject'  => 'role',
+                            'rolename' => Decorator::field('rolename'),
+                            'action'   => 'properties',
+                        ],
+                        'icon'    => 'Definition',
+                    ],
+                ];
+                break;
+
+            case 'popup':
+                $tabs = [
+                    'sql'  => [
+                        'title'   => $lang['strsql'],
+                        'url'     => '/src/views/sqledit.php',
+                        'urlvars' => ['action' => 'sql', 'subject' => 'schema'],
+                        'help'    => 'pg.sql',
+                        'icon'    => 'SqlEditor',
+                    ],
+                    'find' => [
+                        'title'   => $lang['strfind'],
+                        'url'     => '/src/views/sqledit.php',
+                        'urlvars' => ['action' => 'find', 'subject' => 'schema'],
+                        'icon'    => 'Search',
+                    ],
+                ];
+                break;
+
+            case 'column':
+                $tabs = [
+                    'properties' => [
+                        'title'   => $lang['strcolprop'],
+                        'url'     => 'colproperties.php',
+                        'urlvars' => [
+                            'subject' => 'column',
+                            'table'   => Decorator::field('table'),
+                            'column'  => Decorator::field('column'),
+                        ],
+                        'icon'    => 'Column',
+                    ],
+                    'privileges' => [
+                        'title'   => $lang['strprivileges'],
+                        'url'     => 'privileges.php',
+                        'urlvars' => [
+                            'subject' => 'column',
+                            'table'   => Decorator::field('table'),
+                            'column'  => Decorator::field('column'),
+                        ],
+                        'help'    => 'pg.privilege',
+                        'icon'    => 'Privileges',
+                    ],
+                ];
+                break;
+
+            case 'fulltext':
+                $tabs = [
+                    'ftsconfigs' => [
+                        'title'   => $lang['strftstabconfigs'],
+                        'url'     => 'fulltext.php',
+                        'urlvars' => ['subject' => 'schema'],
+                        'hide'    => !$data->hasFTS(),
+                        'help'    => 'pg.ftscfg',
+                        'tree'    => true,
+                        'icon'    => 'FtsCfg',
+                    ],
+                    'ftsdicts'   => [
+                        'title'   => $lang['strftstabdicts'],
+                        'url'     => 'fulltext.php',
+                        'urlvars' => ['subject' => 'schema', 'action' => 'viewdicts'],
+                        'hide'    => !$data->hasFTS(),
+                        'help'    => 'pg.ftsdict',
+                        'tree'    => true,
+                        'icon'    => 'FtsDict',
+                    ],
+                    'ftsparsers' => [
+                        'title'   => $lang['strftstabparsers'],
+                        'url'     => 'fulltext.php',
+                        'urlvars' => ['subject' => 'schema', 'action' => 'viewparsers'],
+                        'hide'    => !$data->hasFTS(),
+                        'help'    => 'pg.ftsparser',
+                        'tree'    => true,
+                        'icon'    => 'FtsParser',
+                    ],
+                ];
+                break;
+        }
+
+        // Tabs hook's place
+        $plugin_functions_parameters = [
+            'tabs'    => &$tabs,
+            'section' => $section,
+        ];
+        $plugin_manager->do_hook('tabs', $plugin_functions_parameters);
+
+        return $tabs;
+    }
+
+    /**
+     * Get the URL for the last active tab of a particular tab bar.
+     */
+    public function getLastTabURL($section)
+    {
+        $data = $this->getDatabaseAccessor();
+
+        $tabs = $this->getNavTabs($section);
+
+        if (isset($_SESSION['webdbLastTab'][$section]) && isset($tabs[$_SESSION['webdbLastTab'][$section]])) {
+            $tab = $tabs[$_SESSION['webdbLastTab'][$section]];
+        } else {
+            $tab = reset($tabs);
+        }
+        \PC::debug(['section' => $section, 'tabs' => $tabs, 'tab' => $tab], 'getLastTabURL');
+        return isset($tab['url']) ? $tab : null;
+    }
+
+    /**
+     * Do multi-page navigation.  Displays the prev, next and page options.
+     * @param $page - the page currently viewed
+     * @param $pages - the maximum number of pages
+     * @param $gets -  the parameters to include in the link to the wanted page
+     * @param $max_width - the number of pages to make available at any one time (default = 20)
+     */
+    public function printPages($page, $pages, $gets, $max_width = 20)
+    {
+        $lang = $this->lang;
+
+        $window = 10;
+
+        if ($page < 0 || $page > $pages) {
+            return;
+        }
+
+        if ($pages < 0) {
+            return;
+        }
+
+        if ($max_width <= 0) {
+            return;
+        }
+
+        unset($gets['page']);
+        $url = http_build_query($gets);
+
+        if ($pages > 1) {
+            echo "<p style=\"text-align: center\">\n";
+            if ($page != 1) {
+                echo "<a class=\"pagenav\" href=\"?{$url}&amp;page=1\">{$lang['strfirst']}</a>\n";
+                $temp = $page - 1;
+                echo "<a class=\"pagenav\" href=\"?{$url}&amp;page={$temp}\">{$lang['strprev']}</a>\n";
+            }
+
+            if ($page <= $window) {
+                $min_page = 1;
+                $max_page = min(2 * $window, $pages);
+            } elseif ($page > $window && $pages >= $page + $window) {
+                $min_page = ($page - $window) + 1;
+                $max_page = $page + $window;
+            } else {
+                $min_page = ($page - (2 * $window - ($pages - $page))) + 1;
+                $max_page = $pages;
+            }
+
+            // Make sure min_page is always at least 1
+            // and max_page is never greater than $pages
+            $min_page = max($min_page, 1);
+            $max_page = min($max_page, $pages);
+
+            for ($i = $min_page; $i <= $max_page; $i++) {
+                #if ($i != $page) echo "<a class=\"pagenav\" href=\"?{$url}&amp;page={$i}\">$i</a>\n";
+                if ($i != $page) {
+                    echo "<a class=\"pagenav\" href=\"display.php?{$url}&amp;page={$i}\">$i</a>\n";
+                } else {
+                    echo "$i\n";
+                }
+
+            }
+            if ($page != $pages) {
+                $temp = $page + 1;
+                echo "<a class=\"pagenav\" href=\"display.php?{$url}&amp;page={$temp}\">{$lang['strnext']}</a>\n";
+                echo "<a class=\"pagenav\" href=\"display.php?{$url}&amp;page={$pages}\">{$lang['strlast']}</a>\n";
+            }
+            echo "</p>\n";
+        }
+    }
+
+    /**
+     * Converts a PHP.INI size variable to bytes.  Taken from publically available
+     * function by Chris DeRose, here: http://www.php.net/manual/en/configuration.directives.php#ini.file-uploads
+     * @param $strIniSize The PHP.INI variable
+     * @return size in bytes, false on failure
+     */
+    public function inisizeToBytes($strIniSize)
+    {
+        // This function will take the string value of an ini 'size' parameter,
+        // and return a double (64-bit float) representing the number of bytes
+        // that the parameter represents. Or false if $strIniSize is unparseable.
+        $a_IniParts = [];
+
+        if (!is_string($strIniSize)) {
+            return false;
+        }
+
+        if (!preg_match('/^(\d+)([bkm]*)$/i', $strIniSize, $a_IniParts)) {
+            return false;
+        }
+
+        $nSize   = (double) $a_IniParts[1];
+        $strUnit = strtolower($a_IniParts[2]);
+
+        switch ($strUnit) {
+            case 'm':
+                return ($nSize * (double) 1048576);
+            case 'k':
+                return ($nSize * (double) 1024);
+            case 'b':
+            default:
+                return $nSize;
+        }
+    }
+
+    public function getRequestVars($subject = '')
+    {
+        $v = [];
+        if (!empty($subject)) {
+            $v['subject'] = $subject;
+        }
+
+        if ($this->server_id !== null && $subject != 'root') {
+            $v['server'] = $this->server_id;
+            if ($this->database !== null && $subject != 'server') {
+                $v['database'] = $this->database;
+                if (isset($_REQUEST['schema']) && $subject != 'database') {
+                    $v['schema'] = $_REQUEST['schema'];
+                }
+            }
+        }
+        return $v;
+    }
+
+    public function icon($icon)
+    {
+        if (is_string($icon)) {
+            $path = "/images/themes/{$this->conf['theme']}/{$icon}";
+            if (file_exists(BASE_PATH . $path . '.png')) {
+                return $path . '.png';
+            }
+
+            if (file_exists(BASE_PATH . $path . '.gif')) {
+                return $path . '.gif';
+            }
+
+            $path = "/images/themes/default/{$icon}";
+            if (file_exists(BASE_PATH . $path . '.png')) {
+                return $path . '.png';
+            }
+
+            if (file_exists(BASE_PATH . $path . '.gif')) {
+                return $path . '.gif';
+            }
+
+        } else {
+            // Icon from plugins
+            $path = "/plugins/{$icon[0]}/images/{$icon[1]}";
+            if (file_exists(BASE_PATH . $path . '.png')) {
+                return $path . '.png';
+            }
+
+            if (file_exists(BASE_PATH . $path . '.gif')) {
+                return $path . '.gif';
+            }
+
+        }
+        return '';
+    }
+
+    /**
+     * Function to escape command line parameters
+     * @param $str The string to escape
+     * @return The escaped string
+     */
+    public function escapeShellArg($str)
+    {
+        $data = $this->getDatabaseAccessor();
+        $lang = $this->lang;
+
+        if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
+            // Due to annoying PHP bugs, shell arguments cannot be escaped
+            // (command simply fails), so we cannot allow complex objects
+            // to be dumped.
+            if (preg_match('/^[_.[:alnum:]]+$/', $str)) {
+                return $str;
+            } else {
+                echo $lang['strcannotdumponwindows'];
+                exit;
+            }
+        } else {
+            return escapeshellarg($str);
+        }
+
+    }
+
+    /**
+     * Function to escape command line programs
+     * @param $str The string to escape
+     * @return The escaped string
+     */
+    public function escapeShellCmd($str)
+    {
+        $data = $this->getDatabaseAccessor();
+
+        if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
+            $data->fieldClean($str);
+            return '"' . $str . '"';
+        } else {
+            return escapeshellcmd($str);
+        }
+
+    }
+
+    /**
+     * Get list of servers' groups if existing in the conf
+     * @return a recordset of servers' groups
+     */
+    public function getServersGroups($recordset = false, $group_id = false)
+    {
+        $lang = $this->lang;
+        $grps = [];
+
+        if (isset($this->conf['srv_groups'])) {
+            foreach ($this->conf['srv_groups'] as $i => $group) {
+                if (
+                    (($group_id === false) and (!isset($group['parents']))) /* root */
+                    or (
+                        ($group_id !== false)
+                        and isset($group['parents'])
+                        and in_array($group_id, explode(',',
+                            preg_replace('/\s/', '', $group['parents'])
+                        ))
+                    ) /* nested group */
+                ) {
+                    $grps[$i] = [
+                        'id'     => $i,
+                        'desc'   => $group['desc'],
+                        'icon'   => 'Servers',
+                        'action' => Decorator::url('/views/servers',
+                            [
+                                'group' => Decorator::field('id'),
+                            ]
+                        ),
+                        'branch' => Decorator::url('/tree/servers',
+                            [
+                                'group' => $i,
+                            ]
+                        ),
+                    ];
+                }
+
+            }
+
+            if ($group_id === false) {
+                $grps['all'] = [
+                    'id'     => 'all',
+                    'desc'   => $lang['strallservers'],
+                    'icon'   => 'Servers',
+                    'action' => Decorator::url('/views/servers',
+                        [
+                            'group' => Decorator::field('id'),
+                        ]
+                    ),
+                    'branch' => Decorator::url('/tree/servers',
+                        [
+                            'group' => 'all',
+                        ]
+                    ),
+                ];
+            }
+
+        }
+
+        if ($recordset) {
+            return new ArrayRecordSet($grps);
+        }
+
+        return $grps;
+    }
+
+    /**
+     * Get list of servers
+     * @param $recordset return as RecordSet suitable for printTable if true,
+     *                   otherwise just return an array.
+     * @param $group a group name to filter the returned servers using $this->conf[srv_groups]
+     */
+    public function getServers($recordset = false, $group = false)
+    {
+
+        $logins = isset($_SESSION['webdbLogin']) && is_array($_SESSION['webdbLogin']) ? $_SESSION['webdbLogin'] : [];
+        $srvs   = [];
+
+        if (($group !== false) and ($group !== 'all')) {
+            if (isset($this->conf['srv_groups'][$group]['servers'])) {
+                $group = array_fill_keys(explode(',', preg_replace('/\s/', '',
+                    $this->conf['srv_groups'][$group]['servers'])), 1);
+            } else {
+                $group = '';
+            }
+        }
+
+        foreach ($this->conf['servers'] as $idx => $info) {
+            $server_id = $info['host'] . ':' . $info['port'] . ':' . $info['sslmode'];
+            if (($group === false)
+                or (isset($group[$idx]))
+                or ($group === 'all')
+            ) {
+                $server_id = $info['host'] . ':' . $info['port'] . ':' . $info['sslmode'];
+
+                if (isset($logins[$server_id])) {
+                    $srvs[$server_id] = $logins[$server_id];
+                } else {
+                    $srvs[$server_id] = $info;
+                }
+
+                $srvs[$server_id]['id']     = $server_id;
+                $srvs[$server_id]['action'] = Decorator::url('/redirect/server',
+                    [
+                        'server' => Decorator::field('id'),
+                    ]
+                );
+                if (isset($srvs[$server_id]['username'])) {
+                    $srvs[$server_id]['icon']   = 'Server';
+                    $srvs[$server_id]['branch'] = Decorator::url('all_db.php',
+                        [
+                            'action'  => 'tree',
+                            'subject' => 'server',
+                            'server'  => Decorator::field('id'),
+                        ]
+                    );
+                } else {
+                    $srvs[$server_id]['icon']   = 'DisconnectedServer';
+                    $srvs[$server_id]['branch'] = false;
+                }
+            }
+        }
+
+        uasort($srvs, ['self', '_cmp_desc']);
+
+        if ($recordset) {
+            return new ArrayRecordSet($srvs);
+        }
+        return $srvs;
+    }
+
+    public function getServerId()
+    {
+        return $this->server_id;
+    }
+
+    /**
+     * Validate and retrieve information on a server.
+     * If the parameter isn't supplied then the currently
+     * connected server is returned.
+     * @param $server_id A server identifier (host:port)
+     * @return An associative array of server properties
+     */
+    public function getServerInfo($server_id = null)
+    {
+
+        //\PC::debug(['$server_id' => $server_id]);
+
+        if ($server_id !== null) {
+            $this->server_id = $server_id;
+        } else if ($this->server_info !== null) {
+            return $this->server_info;
+        }
+
+        // Check for the server in the logged-in list
+        if (isset($_SESSION['webdbLogin'][$this->server_id])) {
+            $this->server_info = $_SESSION['webdbLogin'][$this->server_id];
+            return $this->server_info;
+        }
+
+        // Otherwise, look for it in the conf file
+        foreach ($this->conf['servers'] as $idx => $info) {
+            if ($this->server_id == $info['host'] . ':' . $info['port'] . ':' . $info['sslmode']) {
+                // Automatically use shared credentials if available
+                if (!isset($info['username']) && isset($_SESSION['sharedUsername'])) {
+                    $info['username'] = $_SESSION['sharedUsername'];
+                    $info['password'] = $_SESSION['sharedPassword'];
+                    $this->setReloadBrowser(true);
+                    $this->setServerInfo(null, $info, $this->server_id);
+                }
+                $this->server_info = $info;
+                return $this->server_info;
+
+            }
+        }
+
+        if ($server_id === null) {
+            $this->server_info = null;
+            return $this->server_info;
+
+        } else {
+            $this->server_info = null;
+            // Unable to find a matching server, are we being hacked?
+            echo $this->lang['strinvalidserverparam'];
+
+            exit;
+        }
+    }
+
+    /**
+     * Set server information.
+     * @param $key parameter name to set, or null to replace all
+     *             params with the assoc-array in $value.
+     * @param $value the new value, or null to unset the parameter
+     * @param $server_id the server identifier, or null for current
+     *                   server.
+     */
+    public function setServerInfo($key, $value, $server_id = null)
+    {
+        //\PC::debug('setsetverinfo');
+        if ($server_id === null && isset($_REQUEST['server'])) {
+            $server_id = $_REQUEST['server'];
+        }
+
+        if ($key === null) {
+            if ($value === null) {
+                unset($_SESSION['webdbLogin'][$server_id]);
+            } else {
+                //\PC::debug(['server_id' => $server_id, 'value' => $value], 'webdbLogin null key');
+                $_SESSION['webdbLogin'][$server_id] = $value;
+            }
+
+        } else {
+            if ($value === null) {
+                unset($_SESSION['webdbLogin'][$server_id][$key]);
+            } else {
+                //\PC::debug(['server_id' => $server_id, 'key' => $key, 'value' => $value], __FILE__ . ' ' . __LINE__ . ' webdbLogin key ' . $key);
+                $_SESSION['webdbLogin'][$server_id][$key] = $value;
+            }
+
+        }
+    }
+
+    /**
+     * Set the current schema
+     * @param $schema The schema name
+     * @return 0 on success
+     * @return $data->seSchema() on error
+     */
+    public function setCurrentSchema($schema)
+    {
+        $data = $this->getDatabaseAccessor();
+
+        $status = $data->setSchema($schema);
+        if ($status != 0) {
+            return $status;
+        }
+
+        $_REQUEST['schema'] = $schema;
+        $this->setHREF();
+        return 0;
+    }
+
+    /**
+     * Save the given SQL script in the history
+     * of the database and server.
+     * @param $script the SQL script to save.
+     */
+    public function saveScriptHistory($script)
+    {
+        list($usec, $sec)                                                         = explode(' ', microtime());
+        $time                                                                     = ((float) $usec + (float) $sec);
+        $_SESSION['history'][$_REQUEST['server']][$_REQUEST['database']]["$time"] = [
+            'query'    => $script,
+            'paginate' => (!isset($_REQUEST['paginate']) ? 'f' : 't'),
+            'queryid'  => $time,
+        ];
+    }
+
+    /*
+     * Output dropdown list to select server and
+     * databases form the popups windows.
+     * @param $onchange Javascript action to take when selections change.
+     */
+    public function printConnection($onchange, $do_print = true)
+    {
+        $lang = $this->lang;
+
+        $connection_html = "<table class=\"printconnection\" style=\"width: 100%\"><tr><td class=\"popup_select1\">\n";
+
+        $servers      = $this->getServers();
+        $forcedserver = null;
+        if (count($servers) === 1) {
+            $forcedserver = $this->server_id;
+            $connection_html .= '<input type="hidden" readonly="readonly" value="' . $this->server_id . '" name="server">';
+        } else {
+            $connection_html .= "<label>";
+            $connection_html .= $this->printHelp($lang['strserver'], 'pg.server', false);
+            $connection_html .= ": </label>";
+            $connection_html .= " <select name=\"server\" {$onchange}>\n";
+            foreach ($servers as $info) {
+                if (empty($info['username'])) {
+                    continue;
+                }
+                $selected = ((isset($_REQUEST['server']) && $info['id'] == $_REQUEST['server'])) ? ' selected="selected"' : '';
+                // not logged on this server
+                $connection_html .= "<option value=\"" . htmlspecialchars($info['id']) . "\" " . $selected . ">";
+                $connection_html .= htmlspecialchars("{$info['desc']} ({$info['id']})");
+                $connection_html .= "</option>\n";
+            }
+            $connection_html .= "</select>\n";
+        }
+
+        $connection_html .= "</td><td class=\"popup_select2\" style=\"text-align: right\">\n";
+
+        if (count($servers) === 1 && isset($servers[$this->server_id]['useonlydefaultdb']) && $servers[$this->server_id]['useonlydefaultdb'] === true) {
+
+            $connection_html .= "<input type=\"hidden\" name=\"database\" value=\"" . htmlspecialchars($servers[$this->server_id]['defaultdb']) . "\" />\n";
+
+        } else {
+
+            // Get the list of all databases
+            $data      = $this->getDatabaseAccessor();
+            $databases = $data->getDatabases();
+            if ($databases->recordCount() > 0) {
+
+                $connection_html .= "<label>";
+                $connection_html .= $this->printHelp($lang['strdatabase'], 'pg.database', false);
+                $connection_html .= ": <select name=\"database\" {$onchange}>\n";
+
+                //if no database was selected, user should select one
+                if (!isset($_REQUEST['database'])) {
+                    $connection_html .= "<option value=\"\">--</option>\n";
+                }
+
+                while (!$databases->EOF) {
+                    $dbname     = $databases->fields['datname'];
+                    $dbselected = ((isset($_REQUEST['database']) && $dbname == $_REQUEST['database'])) ? ' selected="selected"' : '';
+                    $connection_html .= "<option value=\"" . htmlspecialchars($dbname) . "\" " . $dbselected . ">" . htmlspecialchars($dbname) . "</option>\n";
+
+                    $databases->moveNext();
+                }
+                $connection_html .= "</select></label>\n";
+            } else {
+                $server_info = $misc->getServerInfo();
+                $connection_html .= "<input type=\"hidden\" name=\"database\" value=\"" . htmlspecialchars($server_info['defaultdb']) . "\" />\n";
+            }
+        }
+
+        $connection_html .= "</td></tr></table>\n";
+
+        if ($do_print) {
+            echo $connection_html;
+        } else {
+            return $connection_html;
+        }
+
+    }
+
+    /**
+     * returns an array representing FKs definition for a table, sorted by fields
+     * or by constraint.
+     * @param $table The table to retrieve FK contraints from
+     * @returns the array of FK definition:
+     *   array(
+     *     'byconstr' => array(
+     *       constrain id => array(
+     *         confrelid => foreign relation oid
+     *         f_schema => foreign schema name
+     *         f_table => foreign table name
+     *         pattnums => array of parent's fields nums
+     *         pattnames => array of parent's fields names
+     *         fattnames => array of foreign attributes names
+     *       )
+     *     ),
+     *     'byfield' => array(
+     *       attribute num => array (constraint id, ...)
+     *     ),
+     *     'code' => HTML/js code to include in the page for auto-completion
+     *   )
+     **/
+    public function getAutocompleteFKProperties($table)
+    {
+        $data = $this->getDatabaseAccessor();
+
+        $fksprops = [
+            'byconstr' => [],
+            'byfield'  => [],
+            'code'     => '',
+        ];
+
+        $constrs = $data->getConstraintsWithFields($table);
+
+        if (!$constrs->EOF) {
+            $conrelid = $constrs->fields['conrelid'];
+            while (!$constrs->EOF) {
+                if ($constrs->fields['contype'] == 'f') {
+                    if (!isset($fksprops['byconstr'][$constrs->fields['conid']])) {
+                        $fksprops['byconstr'][$constrs->fields['conid']] = [
+                            'confrelid' => $constrs->fields['confrelid'],
+                            'f_table'   => $constrs->fields['f_table'],
+                            'f_schema'  => $constrs->fields['f_schema'],
+                            'pattnums'  => [],
+                            'pattnames' => [],
+                            'fattnames' => [],
+                        ];
+                    }
+
+                    $fksprops['byconstr'][$constrs->fields['conid']]['pattnums'][]  = $constrs->fields['p_attnum'];
+                    $fksprops['byconstr'][$constrs->fields['conid']]['pattnames'][] = $constrs->fields['p_field'];
+                    $fksprops['byconstr'][$constrs->fields['conid']]['fattnames'][] = $constrs->fields['f_field'];
+
+                    if (!isset($fksprops['byfield'][$constrs->fields['p_attnum']])) {
+                        $fksprops['byfield'][$constrs->fields['p_attnum']] = [];
+                    }
+
+                    $fksprops['byfield'][$constrs->fields['p_attnum']][] = $constrs->fields['conid'];
+                }
+                $constrs->moveNext();
+            }
+
+            $fksprops['code'] = "<script type=\"text/javascript\">\n";
+            $fksprops['code'] .= "var constrs = {};\n";
+            foreach ($fksprops['byconstr'] as $conid => $props) {
+                $fksprops['code'] .= "constrs.constr_{$conid} = {\n";
+                $fksprops['code'] .= 'pattnums: [' . implode(',', $props['pattnums']) . "],\n";
+                $fksprops['code'] .= "f_table:'" . addslashes(htmlentities($props['f_table'], ENT_QUOTES, 'UTF-8')) . "',\n";
+                $fksprops['code'] .= "f_schema:'" . addslashes(htmlentities($props['f_schema'], ENT_QUOTES, 'UTF-8')) . "',\n";
+                $_ = '';
+                foreach ($props['pattnames'] as $n) {
+                    $_ .= ",'" . htmlentities($n, ENT_QUOTES, 'UTF-8') . "'";
+                }
+                $fksprops['code'] .= 'pattnames: [' . substr($_, 1) . "],\n";
+
+                $_ = '';
+                foreach ($props['fattnames'] as $n) {
+                    $_ .= ",'" . htmlentities($n, ENT_QUOTES, 'UTF-8') . "'";
+                }
+
+                $fksprops['code'] .= 'fattnames: [' . substr($_, 1) . "]\n";
+                $fksprops['code'] .= "};\n";
+            }
+
+            $fksprops['code'] .= "var attrs = {};\n";
+            foreach ($fksprops['byfield'] as $attnum => $cstrs) {
+                $fksprops['code'] .= "attrs.attr_{$attnum} = [" . implode(',', $fksprops['byfield'][$attnum]) . "];\n";
+            }
+
+            $fksprops['code'] .= "var table='" . addslashes(htmlentities($table, ENT_QUOTES, 'UTF-8')) . "';";
+            $fksprops['code'] .= "var server='" . htmlentities($_REQUEST['server'], ENT_QUOTES, 'UTF-8') . "';";
+            $fksprops['code'] .= "var database='" . addslashes(htmlentities($_REQUEST['database'], ENT_QUOTES, 'UTF-8')) . "';";
+            $fksprops['code'] .= "</script>\n";
+
+            $fksprops['code'] .= '<div id="fkbg"></div>';
+            $fksprops['code'] .= '<div id="fklist"></div>';
+            $fksprops['code'] .= '<script src="/js/ac_insert_row.js" type="text/javascript"></script>';
+        } else /* we have no foreign keys on this table */
+        {
+            return false;
+        }
+
+        return $fksprops;
+    }
 }

--- a/src/controllers/DisplayController.php
+++ b/src/controllers/DisplayController.php
@@ -5,1024 +5,1043 @@ namespace PHPPgAdmin\Controller;
 /**
  * Base controller class
  */
-class DisplayController extends BaseController {
-	public $_name = 'DisplayController';
-
-	/* Constructor */
-	function __construct(\Slim\Container $container) {
-		parent::__construct($container);
-
-		// Prevent timeouts on large exports (non-safe mode only)
-		if (!ini_get('safe_mode')) {
-			set_time_limit(0);
-		}
-	}
-
-	public function render() {
-		$conf = $this->conf;
-		$misc = $this->misc;
-		$lang = $this->lang;
-		$plugin_manager = $this->plugin_manager;
-		$data = $misc->getDatabaseAccessor();
-		$action = $this->action;
-
-		/* shortcuts: this function exit the script for ajax purpose */
-		if ($action == 'dobrowsefk') {
-			$this->doBrowseFK();
-		}
-
-		$scripts = "<script src=\"/js/display.js\" type=\"text/javascript\"></script>";
-
-		$scripts .= "<script type=\"text/javascript\">\n";
-		$scripts .= "var Display = {\n";
-		$scripts .= "errmsg: '" . str_replace("'", "\'", $lang['strconnectionfail']) . "'\n";
-		$scripts .= "};\n";
-		$scripts .= "</script>\n";
-
-		$footer_template = 'footer.twig';
-		$header_template = 'header.twig';
-
-		ob_start();
-		switch ($action) {
-		case 'editrow':
-			if (isset($_POST['save'])) {
-				$this->doEditRow(false);
-			} else {
-				$header_template = 'sqledit_header.twig';
-				$footer_template = 'sqledit_footer.twig';
-				$this->doBrowse();
-			}
-
-			break;
-		case 'confeditrow':
-			$this->doEditRow(true);
-			break;
-		case 'delrow':
-			if (isset($_POST['yes'])) {
-				$this->doDelRow(false);
-			} else {
-				$header_template = 'sqledit_header.twig';
-				$footer_template = 'sqledit_footer.twig';
-				$this->doBrowse();
-			}
-
-			break;
-		case 'confdelrow':
-			$this->doDelRow(true);
-			break;
-		default:
-			$header_template = 'sqledit_header.twig';
-			$footer_template = 'sqledit_footer.twig';
-			$this->doBrowse();
-			break;
-		}
-		$output = ob_get_clean();
-
-		// Set the title based on the subject of the request
-		if (isset($_REQUEST['subject']) && isset($_REQUEST[$_REQUEST['subject']])) {
-			if ($_REQUEST['subject'] == 'table') {
-				$this->printHeader(
-					$lang['strtables'] . ': ' . $_REQUEST[$_REQUEST['subject']],
-					$scripts, true, $header_template
-				);
-			} else if ($_REQUEST['subject'] == 'view') {
-				$this->printHeader(
-					$lang['strviews'] . ': ' . $_REQUEST[$_REQUEST['subject']],
-					$scripts, true, $header_template
-				);
-			} else if ($_REQUEST['subject'] == 'matview') {
-				$this->printHeader(
-					'M' . $lang['strviews'] . ': ' . $_REQUEST[$_REQUEST['subject']],
-					$scripts, true, $header_template
-				);
-			} else if ($_REQUEST['subject'] == 'column') {
-				$this->printHeader(
-					$lang['strcolumn'] . ': ' . $_REQUEST[$_REQUEST['subject']],
-					$scripts, true, $header_template
-				);
-			}
-		} else {
-			$this->printHeader($lang['strqueryresults'], $scripts, true, $header_template);
-		}
-
-		$this->printBody();
-
-		echo $output;
-
-		$misc->printFooter(true, $footer_template);
-	}
-
-	/**
-	 * Displays requested data
-	 */
-	function doBrowse($msg = '') {
-		$conf = $this->conf;
-		$misc = $this->misc;
-		$lang = $this->lang;
-		$plugin_manager = $this->plugin_manager;
-		$data = $misc->getDatabaseAccessor();
-
-		$save_history = false;
-		// If current page is not set, default to first page
-		if (!isset($_REQUEST['page'])) {
-			$_REQUEST['page'] = 1;
-		}
-
-		if (!isset($_REQUEST['nohistory'])) {
-			$save_history = true;
-		}
-
-		if (isset($_REQUEST['subject'])) {
-			$subject = $_REQUEST['subject'];
-			if (isset($_REQUEST[$subject])) {
-				$object = $_REQUEST[$subject];
-			}
-
-		} else {
-			$subject = '';
-		}
-
-		$this->printTrail(isset($subject) ? $subject : 'database');
-		$this->printTabs($subject, 'browse');
-
-		/* This code is used when browsing FK in pure-xHTML (without js) */
-		if (isset($_REQUEST['fkey'])) {
-			$ops = [];
-			foreach ($_REQUEST['fkey'] as $x => $y) {
-				$ops[$x] = '=';
-			}
-			$query = $data->getSelectSQL($_REQUEST['table'], [], $_REQUEST['fkey'], $ops);
-			$_REQUEST['query'] = $query;
-		}
-
-		if (isset($object)) {
-			if (isset($_REQUEST['query'])) {
-				$_SESSION['sqlquery'] = $_REQUEST['query'];
-				$this->printTitle($lang['strselect']);
-				$type = 'SELECT';
-			} else {
-				$type = 'TABLE';
-			}
-		} else {
-			$this->printTitle($lang['strqueryresults']);
-			/*we comes from sql.php, $_SESSION['sqlquery'] has been set there */
-			$type = 'QUERY';
-		}
-
-		$misc->printMsg($msg);
-
-		// If 'sortkey' is not set, default to ''
-		if (!isset($_REQUEST['sortkey'])) {
-			$_REQUEST['sortkey'] = '';
-		}
-
-		// If 'sortdir' is not set, default to ''
-		if (!isset($_REQUEST['sortdir'])) {
-			$_REQUEST['sortdir'] = '';
-		}
-
-		// If 'strings' is not set, default to collapsed
-		if (!isset($_REQUEST['strings'])) {
-			$_REQUEST['strings'] = 'collapsed';
-		}
-
-		// Fetch unique row identifier, if this is a table browse request.
-		if (isset($object)) {
-			$key = $data->getRowIdentifier($object);
-		} else {
-			$key = [];
-		}
-
-		// Set the schema search path
-		if (isset($_REQUEST['search_path'])) {
-			if ($data->setSearchPath(array_map('trim', explode(',', $_REQUEST['search_path']))) != 0) {
-				return;
-			}
-		}
-
-		// Retrieve page from query.  $max_pages is returned by reference.
-		$rs = $data->browseQuery($type,
-			isset($object) ? $object : null,
-			isset($_SESSION['sqlquery']) ? $_SESSION['sqlquery'] : null,
-			$_REQUEST['sortkey'], $_REQUEST['sortdir'], $_REQUEST['page'],
-			$conf['max_rows'], $max_pages);
-
-		$fkey_information = $this->getFKInfo();
-
-		// Build strings for GETs in array
-		$_gets = [
-			'server' => $_REQUEST['server'],
-			'database' => $_REQUEST['database'],
-		];
-
-		if (isset($_REQUEST['schema'])) {
-			$_gets['schema'] = $_REQUEST['schema'];
-		}
-
-		if (isset($object)) {
-			$_gets[$subject] = $object;
-		}
-
-		if (isset($subject)) {
-			$_gets['subject'] = $subject;
-		}
-
-		if (isset($_REQUEST['query'])) {
-			$_gets['query'] = $_REQUEST['query'];
-		}
-
-		if (isset($_REQUEST['count'])) {
-			$_gets['count'] = $_REQUEST['count'];
-		}
-
-		if (isset($_REQUEST['return'])) {
-			$_gets['return'] = $_REQUEST['return'];
-		}
-
-		if (isset($_REQUEST['search_path'])) {
-			$_gets['search_path'] = $_REQUEST['search_path'];
-		}
-
-		if (isset($_REQUEST['table'])) {
-			$_gets['table'] = $_REQUEST['table'];
-		}
-
-		if (isset($_REQUEST['sortkey'])) {
-			$_gets['sortkey'] = $_REQUEST['sortkey'];
-		}
-
-		if (isset($_REQUEST['sortdir'])) {
-			$_gets['sortdir'] = $_REQUEST['sortdir'];
-		}
-
-		if (isset($_REQUEST['nohistory'])) {
-			$_gets['nohistory'] = $_REQUEST['nohistory'];
-		}
-
-		$_gets['strings'] = $_REQUEST['strings'];
-
-		if ($save_history && is_object($rs) && ($type == 'QUERY')) //{
-		{
-			$misc->saveScriptHistory($_REQUEST['query']);
-		}
-
-		echo '<form method="POST" id="sqlform" action="' . $_SERVER['REQUEST_URI'] . '">';
-		echo '<textarea width="90%" name="query"  id="query" rows="5" cols="100" resizable="true">';
-		if (isset($_REQUEST['query'])) {
-			$query = $_REQUEST['query'];
-		} else {
-			$query = "SELECT * FROM {$_REQUEST['schema']}";
-			if ($_REQUEST['subject'] == 'matview') {
-				$query = "{$query}.{$_REQUEST['matview']};";
-			} else if ($_REQUEST['subject'] == 'view') {
-				$query = "{$query}.{$_REQUEST['view']};";
-			} else {
-				$query = "{$query}.{$_REQUEST['table']};";
-			}
-		}
-		//$query = isset($_REQUEST['query'])? $_REQUEST['query'] : "select * from {$_REQUEST['schema']}.{$_REQUEST['table']};";
-		echo $query;
-		echo '</textarea><br><input type="submit"/></form>';
-
-		if (is_object($rs) && $rs->recordCount() > 0) {
-			// Show page navigation
-			$misc->printPages($_REQUEST['page'], $max_pages, $_gets);
-
-			echo "<table id=\"data\">\n<tr>";
-
-			// Check that the key is actually in the result set.  This can occur for select
-			// operations where the key fields aren't part of the select.  XXX:  We should
-			// be able to support this, somehow.
-			foreach ($key as $v) {
-				// If a key column is not found in the record set, then we
-				// can't use the key.
-				if (!in_array($v, array_keys($rs->fields))) {
-					$key = [];
-					break;
-				}
-			}
-
-			$buttons = [
-				'edit' => [
-					'content' => $lang['stredit'],
-					'attr' => [
-						'href' => [
-							'url' => 'display.php',
-							'urlvars' => array_merge([
-								'action' => 'confeditrow',
-								'strings' => $_REQUEST['strings'],
-								'page' => $_REQUEST['page'],
-							], $_gets),
-						],
-					],
-				],
-				'delete' => [
-					'content' => $lang['strdelete'],
-					'attr' => [
-						'href' => [
-							'url' => 'display.php',
-							'urlvars' => array_merge([
-								'action' => 'confdelrow',
-								'strings' => $_REQUEST['strings'],
-								'page' => $_REQUEST['page'],
-							], $_gets),
-						],
-					],
-				],
-			];
-			$actions = [
-				'actionbuttons' => &$buttons,
-				'place' => 'display-browse',
-			];
-			$plugin_manager->do_hook('actionbuttons', $actions);
-
-			foreach (array_keys($actions['actionbuttons']) as $action) {
-				$actions['actionbuttons'][$action]['attr']['href']['urlvars'] = array_merge(
-					$actions['actionbuttons'][$action]['attr']['href']['urlvars'],
-					$_gets
-				);
-			}
-
-			$edit_params = isset($actions['actionbuttons']['edit']) ?
-			$actions['actionbuttons']['edit'] : [];
-			$delete_params = isset($actions['actionbuttons']['delete']) ?
-			$actions['actionbuttons']['delete'] : [];
-
-			// Display edit and delete actions if we have a key
-			$colspan = count($buttons);
-			if ($colspan > 0 and count($key) > 0) {
-				echo "<th colspan=\"{$colspan}\" class=\"data\">{$lang['stractions']}</th>\n";
-			}
-
-			/* we show OIDs only if we are in TABLE or SELECT type browsing */
-			$this->printTableHeaderCells($rs, $_gets, isset($object));
-
-			echo "</tr>\n";
-
-			$i = 0;
-			reset($rs->fields);
-			while (!$rs->EOF) {
-				$id = (($i % 2) == 0 ? '1' : '2');
-				echo "<tr class=\"data{$id}\">\n";
-				// Display edit and delete links if we have a key
-				if ($colspan > 0 and count($key) > 0) {
-					$keys_array = [];
-					$has_nulls = false;
-					foreach ($key as $v) {
-						if ($rs->fields[$v] === null) {
-							$has_nulls = true;
-							break;
-						}
-						$keys_array["key[{$v}]"] = $rs->fields[$v];
-					}
-					if ($has_nulls) {
-						echo "<td colspan=\"{$colspan}\">&nbsp;</td>\n";
-					} else {
-
-						if (isset($actions['actionbuttons']['edit'])) {
-							$actions['actionbuttons']['edit'] = $edit_params;
-							$actions['actionbuttons']['edit']['attr']['href']['urlvars'] = array_merge(
-								$actions['actionbuttons']['edit']['attr']['href']['urlvars'],
-								$keys_array
-							);
-						}
-
-						if (isset($actions['actionbuttons']['delete'])) {
-							$actions['actionbuttons']['delete'] = $delete_params;
-							$actions['actionbuttons']['delete']['attr']['href']['urlvars'] = array_merge(
-								$actions['actionbuttons']['delete']['attr']['href']['urlvars'],
-								$keys_array
-							);
-						}
-
-						foreach ($actions['actionbuttons'] as $action) {
-							echo "<td class=\"opbutton{$id}\">";
-							$this->printLink($action);
-							echo "</td>\n";
-						}
-					}
-				}
-
-				$this->printTableRowCells($rs, $fkey_information, isset($object));
-
-				echo "</tr>\n";
-				$rs->moveNext();
-				$i++;
-			}
-			echo "</table>\n";
-
-			echo "<p>", $rs->recordCount(), " {$lang['strrows']}</p>\n";
-			// Show page navigation
-			$misc->printPages($_REQUEST['page'], $max_pages, $_gets);
-		} else {
-			echo "<p>{$lang['strnodata']}</p>\n";
-		}
-
-		// Navigation links
-		$navlinks = [];
-
-		$fields = [
-			'server' => $_REQUEST['server'],
-			'database' => $_REQUEST['database'],
-		];
-
-		if (isset($_REQUEST['schema'])) {
-			$fields['schema'] = $_REQUEST['schema'];
-		}
-
-		// Return
-		if (isset($_REQUEST['return'])) {
-			$urlvars = $misc->getSubjectParams($_REQUEST['return']);
-
-			$navlinks['back'] = [
-				'attr' => [
-					'href' => [
-						'url' => $urlvars['url'],
-						'urlvars' => $urlvars['params'],
-					],
-				],
-				'content' => $lang['strback'],
-			];
-		}
-
-		// Edit SQL link
-		if ($type == 'QUERY') {
-			$navlinks['edit'] = [
-				'attr' => [
-					'href' => [
-						'url' => 'database.php',
-						'urlvars' => array_merge($fields, [
-							'action' => 'sql',
-							'paginate' => 'on',
-						]),
-					],
-				],
-				'content' => $lang['streditsql'],
-			];
-		}
-
-		// Expand/Collapse
-		if ($_REQUEST['strings'] == 'expanded') {
-			$navlinks['collapse'] = [
-				'attr' => [
-					'href' => [
-						'url' => 'display.php',
-						'urlvars' => array_merge(
-							$_gets,
-							[
-								'strings' => 'collapsed',
-								'page' => $_REQUEST['page'],
-							]),
-					],
-				],
-				'content' => $lang['strcollapse'],
-			];
-		} else {
-			$navlinks['collapse'] = [
-				'attr' => [
-					'href' => [
-						'url' => 'display.php',
-						'urlvars' => array_merge(
-							$_gets,
-							[
-								'strings' => 'expanded',
-								'page' => $_REQUEST['page'],
-							]),
-					],
-				],
-				'content' => $lang['strexpand'],
-			];
-		}
-
-		// Create view and download
-		if (isset($_REQUEST['query']) && isset($rs) && is_object($rs) && $rs->recordCount() > 0) {
-
-			// Report views don't set a schema, so we need to disable create view in that case
-			if (isset($_REQUEST['schema'])) {
-
-				$navlinks['createview'] = [
-					'attr' => [
-						'href' => [
-							'url' => 'views.php',
-							'urlvars' => array_merge($fields, [
-								'action' => 'create',
-								'formDefinition' => $_REQUEST['query'],
-							]),
-						],
-					],
-					'content' => $lang['strcreateview'],
-				];
-			}
-
-			$urlvars = [];
-			if (isset($_REQUEST['search_path'])) {
-				$urlvars['search_path'] = $_REQUEST['search_path'];
-			}
-
-			$navlinks['download'] = [
-				'attr' => [
-					'href' => [
-						'url' => 'dataexport.php',
-						'urlvars' => array_merge($fields, $urlvars),
-					],
-				],
-				'content' => $lang['strdownload'],
-			];
-		}
-
-		// Insert
-		if (isset($object) && (isset($subject) && $subject == 'table')) {
-			$navlinks['insert'] = [
-				'attr' => [
-					'href' => [
-						'url' => 'tables.php',
-						'urlvars' => array_merge($fields, [
-							'action' => 'confinsertrow',
-							'table' => $object,
-						]),
-					],
-				],
-				'content' => $lang['strinsert'],
-			];
-		}
-
-		// Refresh
-		$navlinks['refresh'] = [
-			'attr' => [
-				'href' => [
-					'url' => 'display.php',
-					'urlvars' => array_merge(
-						$_gets,
-						[
-							'strings' => $_REQUEST['strings'],
-							'page' => $_REQUEST['page'],
-						]),
-				],
-			],
-			'content' => $lang['strrefresh'],
-		];
-
-		$this->printNavLinks($navlinks, 'display-browse', get_defined_vars());
-	}
-	/**
-	 * Show confirmation of edit and perform actual update
-	 */
-	function doEditRow($confirm, $msg = '') {
-		$conf = $this->conf;
-		$misc = $this->misc;
-		$lang = $this->lang;
-		$data = $misc->getDatabaseAccessor();
-
-		if (is_array($_REQUEST['key'])) {
-			$key = $_REQUEST['key'];
-		} else {
-			$key = unserialize(urldecode($_REQUEST['key']));
-		}
-
-		if ($confirm) {
-			$this->printTrail($_REQUEST['subject']);
-			$this->printTitle($lang['streditrow']);
-			$misc->printMsg($msg);
-
-			$attrs = $data->getTableAttributes($_REQUEST['table']);
-			$rs = $data->browseRow($_REQUEST['table'], $key);
-
-			if (($conf['autocomplete'] != 'disable')) {
-				$fksprops = $misc->getAutocompleteFKProperties($_REQUEST['table']);
-				if ($fksprops !== false) {
-					echo $fksprops['code'];
-				}
-
-			} else {
-				$fksprops = false;
-			}
-
-			echo "<form action=\"/src/views/display.php\" method=\"post\" id=\"ac_form\">\n";
-			$elements = 0;
-			$error = true;
-			if ($rs->recordCount() == 1 && $attrs->recordCount() > 0) {
-				echo "<table>\n";
-
-				// Output table header
-				echo "<tr><th class=\"data\">{$lang['strcolumn']}</th><th class=\"data\">{$lang['strtype']}</th>";
-				echo "<th class=\"data\">{$lang['strformat']}</th>\n";
-				echo "<th class=\"data\">{$lang['strnull']}</th><th class=\"data\">{$lang['strvalue']}</th></tr>";
-
-				$i = 0;
-				while (!$attrs->EOF) {
-
-					$attrs->fields['attnotnull'] = $data->phpBool($attrs->fields['attnotnull']);
-					$id = (($i % 2) == 0 ? '1' : '2');
-
-					// Initialise variables
-					if (!isset($_REQUEST['format'][$attrs->fields['attname']])) {
-						$_REQUEST['format'][$attrs->fields['attname']] = 'VALUE';
-					}
-
-					echo "<tr class=\"data{$id}\">\n";
-					echo "<td style=\"white-space:nowrap;\">", $misc->printVal($attrs->fields['attname']), "</td>";
-					echo "<td style=\"white-space:nowrap;\">\n";
-					echo $misc->printVal($data->formatType($attrs->fields['type'], $attrs->fields['atttypmod']));
-					echo "<input type=\"hidden\" name=\"types[", htmlspecialchars($attrs->fields['attname']), "]\" value=\"",
-					htmlspecialchars($attrs->fields['type']), "\" /></td>";
-					$elements++;
-					echo "<td style=\"white-space:nowrap;\">\n";
-					echo "<select name=\"format[", htmlspecialchars($attrs->fields['attname']), "]\">\n";
-					echo "<option value=\"VALUE\"", ($_REQUEST['format'][$attrs->fields['attname']] == 'VALUE') ? ' selected="selected"' : '', ">{$lang['strvalue']}</option>\n";
-					echo "<option value=\"EXPRESSION\"", ($_REQUEST['format'][$attrs->fields['attname']] == 'EXPRESSION') ? ' selected="selected"' : '', ">{$lang['strexpression']}</option>\n";
-					echo "</select>\n</td>\n";
-					$elements++;
-					echo "<td style=\"white-space:nowrap;\">";
-					// Output null box if the column allows nulls (doesn't look at CHECKs or ASSERTIONS)
-					if (!$attrs->fields['attnotnull']) {
-						// Set initial null values
-						if ($_REQUEST['action'] == 'confeditrow' && $rs->fields[$attrs->fields['attname']] === null) {
-							$_REQUEST['nulls'][$attrs->fields['attname']] = 'on';
-						}
-						echo "<label><span><input type=\"checkbox\" name=\"nulls[{$attrs->fields['attname']}]\"",
-						isset($_REQUEST['nulls'][$attrs->fields['attname']]) ? ' checked="checked"' : '', " /></span></label></td>\n";
-						$elements++;
-					} else {
-						echo "&nbsp;</td>";
-					}
-
-					echo "<td id=\"row_att_{$attrs->fields['attnum']}\" style=\"white-space:nowrap;\">";
-
-					$extras = [];
-
-					// If the column allows nulls, then we put a JavaScript action on the data field to unset the
-					// NULL checkbox as soon as anything is entered in the field.  We use the $elements variable to
-					// keep track of which element offset we're up to.  We can't refer to the null checkbox by name
-					// as it contains '[' and ']' characters.
-					if (!$attrs->fields['attnotnull']) {
-						$extras['onChange'] = 'elements[' . ($elements - 1) . '].checked = false;';
-					}
-
-					if (($fksprops !== false) && isset($fksprops['byfield'][$attrs->fields['attnum']])) {
-						$extras['id'] = "attr_{$attrs->fields['attnum']}";
-						$extras['autocomplete'] = 'off';
-					}
-
-					echo $data->printField("values[{$attrs->fields['attname']}]", $rs->fields[$attrs->fields['attname']], $attrs->fields['type'], $extras);
-
-					echo "</td>";
-					$elements++;
-					echo "</tr>\n";
-					$i++;
-					$attrs->moveNext();
-				}
-				echo "</table>\n";
-
-				$error = false;
-			} elseif ($rs->recordCount() != 1) {
-				echo "<p>{$lang['strrownotunique']}</p>\n";
-			} else {
-				echo "<p>{$lang['strinvalidparam']}</p>\n";
-			}
-
-			echo "<input type=\"hidden\" name=\"action\" value=\"editrow\" />\n";
-			echo $misc->form;
-			if (isset($_REQUEST['table'])) {
-				echo "<input type=\"hidden\" name=\"table\" value=\"", htmlspecialchars($_REQUEST['table']), "\" />\n";
-			}
-
-			if (isset($_REQUEST['subject'])) {
-				echo "<input type=\"hidden\" name=\"subject\" value=\"", htmlspecialchars($_REQUEST['subject']), "\" />\n";
-			}
-
-			if (isset($_REQUEST['query'])) {
-				echo "<input type=\"hidden\" name=\"query\" value=\"", htmlspecialchars($_REQUEST['query']), "\" />\n";
-			}
-
-			if (isset($_REQUEST['count'])) {
-				echo "<input type=\"hidden\" name=\"count\" value=\"", htmlspecialchars($_REQUEST['count']), "\" />\n";
-			}
-
-			if (isset($_REQUEST['return'])) {
-				echo "<input type=\"hidden\" name=\"return\" value=\"", htmlspecialchars($_REQUEST['return']), "\" />\n";
-			}
-
-			echo "<input type=\"hidden\" name=\"page\" value=\"", htmlspecialchars($_REQUEST['page']), "\" />\n";
-			echo "<input type=\"hidden\" name=\"sortkey\" value=\"", htmlspecialchars($_REQUEST['sortkey']), "\" />\n";
-			echo "<input type=\"hidden\" name=\"sortdir\" value=\"", htmlspecialchars($_REQUEST['sortdir']), "\" />\n";
-			echo "<input type=\"hidden\" name=\"strings\" value=\"", htmlspecialchars($_REQUEST['strings']), "\" />\n";
-			echo "<input type=\"hidden\" name=\"key\" value=\"", htmlspecialchars(urlencode(serialize($key))), "\" />\n";
-			echo "<p>";
-			if (!$error) {
-				echo "<input type=\"submit\" name=\"save\" accesskey=\"r\" value=\"{$lang['strsave']}\" />\n";
-			}
-
-			echo "<input type=\"submit\" name=\"cancel\" value=\"{$lang['strcancel']}\" />\n";
-
-			if ($fksprops !== false) {
-				if ($conf['autocomplete'] != 'default off') {
-					echo "<input type=\"checkbox\" id=\"no_ac\" value=\"1\" checked=\"checked\" /><label for=\"no_ac\">{$lang['strac']}</label>\n";
-				} else {
-					echo "<input type=\"checkbox\" id=\"no_ac\" value=\"0\" /><label for=\"no_ac\">{$lang['strac']}</label>\n";
-				}
-
-			}
-
-			echo "</p>\n";
-			echo "</form>\n";
-		} else {
-			if (!isset($_POST['values'])) {
-				$_POST['values'] = [];
-			}
-
-			if (!isset($_POST['nulls'])) {
-				$_POST['nulls'] = [];
-			}
-
-			$status = $data->editRow($_POST['table'], $_POST['values'], $_POST['nulls'],
-				$_POST['format'], $_POST['types'], $key);
-			if ($status == 0) {
-				$this->doBrowse($lang['strrowupdated']);
-			} elseif ($status == -2) {
-				$this->doEditRow(true, $lang['strrownotunique']);
-			} else {
-				$this->doEditRow(true, $lang['strrowupdatedbad']);
-			}
-
-		}
-
-	}
-
-	/**
-	 * Show confirmation of drop and perform actual drop
-	 */
-	function doDelRow($confirm) {
-		$conf = $this->conf;
-		$misc = $this->misc;
-		$lang = $this->lang;
-		$data = $misc->getDatabaseAccessor();
-
-		if ($confirm) {
-			$this->printTrail($_REQUEST['subject']);
-			$this->printTitle($lang['strdeleterow']);
-
-			$rs = $data->browseRow($_REQUEST['table'], $_REQUEST['key']);
-
-			echo "<form action=\"/src/views/display.php\" method=\"post\">\n";
-			echo $misc->form;
-
-			if ($rs->recordCount() == 1) {
-				echo "<p>{$lang['strconfdeleterow']}</p>\n";
-
-				$fkinfo = [];
-				echo "<table><tr>";
-				$this->printTableHeaderCells($rs, false, true);
-				echo "</tr>";
-				echo "<tr class=\"data1\">\n";
-				$this->printTableRowCells($rs, $fkinfo, true);
-				echo "</tr>\n";
-				echo "</table>\n";
-				echo "<br />\n";
-
-				echo "<input type=\"hidden\" name=\"action\" value=\"delrow\" />\n";
-				echo "<input type=\"submit\" name=\"yes\" value=\"{$lang['stryes']}\" />\n";
-				echo "<input type=\"submit\" name=\"no\" value=\"{$lang['strno']}\" />\n";
-			} elseif ($rs->recordCount() != 1) {
-				echo "<p>{$lang['strrownotunique']}</p>\n";
-				echo "<input type=\"submit\" name=\"cancel\" value=\"{$lang['strcancel']}\" />\n";
-			} else {
-				echo "<p>{$lang['strinvalidparam']}</p>\n";
-				echo "<input type=\"submit\" name=\"cancel\" value=\"{$lang['strcancel']}\" />\n";
-			}
-			if (isset($_REQUEST['table'])) {
-				echo "<input type=\"hidden\" name=\"table\" value=\"", htmlspecialchars($_REQUEST['table']), "\" />\n";
-			}
-
-			if (isset($_REQUEST['subject'])) {
-				echo "<input type=\"hidden\" name=\"subject\" value=\"", htmlspecialchars($_REQUEST['subject']), "\" />\n";
-			}
-
-			if (isset($_REQUEST['query'])) {
-				echo "<input type=\"hidden\" name=\"query\" value=\"", htmlspecialchars($_REQUEST['query']), "\" />\n";
-			}
-
-			if (isset($_REQUEST['count'])) {
-				echo "<input type=\"hidden\" name=\"count\" value=\"", htmlspecialchars($_REQUEST['count']), "\" />\n";
-			}
-
-			if (isset($_REQUEST['return'])) {
-				echo "<input type=\"hidden\" name=\"return\" value=\"", htmlspecialchars($_REQUEST['return']), "\" />\n";
-			}
-
-			echo "<input type=\"hidden\" name=\"page\" value=\"", htmlspecialchars($_REQUEST['page']), "\" />\n";
-			echo "<input type=\"hidden\" name=\"sortkey\" value=\"", htmlspecialchars($_REQUEST['sortkey']), "\" />\n";
-			echo "<input type=\"hidden\" name=\"sortdir\" value=\"", htmlspecialchars($_REQUEST['sortdir']), "\" />\n";
-			echo "<input type=\"hidden\" name=\"strings\" value=\"", htmlspecialchars($_REQUEST['strings']), "\" />\n";
-			echo "<input type=\"hidden\" name=\"key\" value=\"", htmlspecialchars(urlencode(serialize($_REQUEST['key']))), "\" />\n";
-			echo "</form>\n";
-		} else {
-			$status = $data->deleteRow($_POST['table'], unserialize(urldecode($_POST['key'])));
-			if ($status == 0) {
-				$this->doBrowse($lang['strrowdeleted']);
-			} elseif ($status == -2) {
-				$this->doBrowse($lang['strrownotunique']);
-			} else {
-				$this->doBrowse($lang['strrowdeletedbad']);
-			}
-
-		}
-
-	}
-
-	/**
-	 * build & return the FK information data structure
-	 * used when deciding if a field should have a FK link or not
-	 * @return [type] [description]
-	 */
-	function &getFKInfo() {
-		$conf = $this->conf;
-		$misc = $this->misc;
-		$lang = $this->lang;
-		$data = $misc->getDatabaseAccessor();
-
-		// Get the foreign key(s) information from the current table
-		$fkey_information = ['byconstr' => [], 'byfield' => []];
-
-		if (isset($_REQUEST['table'])) {
-			$constraints = $data->getConstraintsWithFields($_REQUEST['table']);
-			if ($constraints->recordCount() > 0) {
-
-				$fkey_information['common_url'] = $misc->getHREF('schema') . '&amp;subject=table';
-
-				/* build the FK constraints data structure */
-				while (!$constraints->EOF) {
-					$constr = &$constraints->fields;
-					if ($constr['contype'] == 'f') {
-
-						if (!isset($fkey_information['byconstr'][$constr['conid']])) {
-							$fkey_information['byconstr'][$constr['conid']] = [
-								'url_data' => 'table=' . urlencode($constr['f_table']) . '&amp;schema=' . urlencode($constr['f_schema']),
-								'fkeys' => [],
-								'consrc' => $constr['consrc'],
-							];
-						}
-
-						$fkey_information['byconstr'][$constr['conid']]['fkeys'][$constr['p_field']] = $constr['f_field'];
-
-						if (!isset($fkey_information['byfield'][$constr['p_field']])) {
-							$fkey_information['byfield'][$constr['p_field']] = [];
-						}
-
-						$fkey_information['byfield'][$constr['p_field']][] = $constr['conid'];
-					}
-					$constraints->moveNext();
-				}
-			}
-		}
-
-		return $fkey_information;
-	}
-
-	/**
-	 * Print table header cells
-	 * @param $args - associative array for sort link parameters
-	 *
-	 */
-	function printTableHeaderCells(&$rs, $args, $withOid) {
-		$conf = $this->conf;
-		$misc = $this->misc;
-		$lang = $this->lang;
-		$data = $misc->getDatabaseAccessor();
-		$j = 0;
-
-		foreach ($rs->fields as $k => $v) {
-
-			if (($k === $data->id) && (!($withOid && $conf['show_oids']))) {
-				$j++;
-				continue;
-			}
-			$finfo = $rs->fetchField($j);
-
-			if ($args === false) {
-				echo "<th class=\"data\">", $misc->printVal($finfo->name), "</th>\n";
-			} else {
-				$args['page'] = $_REQUEST['page'];
-				$args['sortkey'] = $j + 1;
-				// Sort direction opposite to current direction, unless it's currently ''
-				$args['sortdir'] = (
-					$_REQUEST['sortdir'] == 'asc'
-					and $_REQUEST['sortkey'] == ($j + 1)
-				) ? 'desc' : 'asc';
-
-				$sortLink = http_build_query($args);
-
-				echo "<th class=\"data\"><a href=\"?{$sortLink}\">"
-				, $misc->printVal($finfo->name);
-				if ($_REQUEST['sortkey'] == ($j + 1)) {
-					if ($_REQUEST['sortdir'] == 'asc') {
-						echo '<img src="' . $misc->icon('RaiseArgument') . '" alt="asc">';
-					} else {
-						echo '<img src="' . $misc->icon('LowerArgument') . '" alt="desc">';
-					}
-
-				}
-				echo "</a></th>\n";
-			}
-			$j++;
-		}
-
-		reset($rs->fields);
-	}
-
-	/* Print data-row cells */
-	function printTableRowCells(&$rs, &$fkey_information, $withOid) {
-		$conf = $this->conf;
-		$misc = $this->misc;
-		$lang = $this->lang;
-		$data = $misc->getDatabaseAccessor();
-		$j = 0;
-
-		if (!isset($_REQUEST['strings'])) {
-			$_REQUEST['strings'] = 'collapsed';
-		}
-
-		foreach ($rs->fields as $k => $v) {
-			$finfo = $rs->fetchField($j++);
-
-			if (($k === $data->id) && (!($withOid && $conf['show_oids']))) {
-				continue;
-			} elseif ($v !== null && $v == '') {
-				echo "<td>&nbsp;</td>";
-			} else {
-				echo "<td style=\"white-space:nowrap;\">";
-
-				if (($v !== null) && isset($fkey_information['byfield'][$k])) {
-					foreach ($fkey_information['byfield'][$k] as $conid) {
-
-						$query_params = $fkey_information['byconstr'][$conid]['url_data'];
-
-						foreach ($fkey_information['byconstr'][$conid]['fkeys'] as $p_field => $f_field) {
-							$query_params .= '&amp;' . urlencode("fkey[{$f_field}]") . '=' . urlencode($rs->fields[$p_field]);
-						}
-
-						/* $fkey_information['common_url'] is already urlencoded */
-						$query_params .= '&amp;' . $fkey_information['common_url'];
-						echo "<div style=\"display:inline-block;\">";
-						echo "<a class=\"fk fk_" . htmlentities($conid, ENT_QUOTES, 'UTF-8') . "\" href=\"display.php?{$query_params}\">";
-						echo "<img src=\"" . $misc->icon('ForeignKey') . "\" style=\"vertical-align:middle;\" alt=\"[fk]\" title=\""
-						. htmlentities($fkey_information['byconstr'][$conid]['consrc'], ENT_QUOTES, 'UTF-8')
-							. "\" />";
-						echo "</a>";
-						echo "</div>";
-					}
-					echo $misc->printVal($v, $finfo->type, ['null' => true, 'clip' => ($_REQUEST['strings'] == 'collapsed'), 'class' => 'fk_value']);
-				} else {
-					echo $misc->printVal($v, $finfo->type, ['null' => true, 'clip' => ($_REQUEST['strings'] == 'collapsed')]);
-				}
-				echo "</td>";
-			}
-		}
-	}
-
-	/* Print the FK row, used in ajax requests */
-	function doBrowseFK() {
-		$conf = $this->conf;
-		$misc = $this->misc;
-		$lang = $this->lang;
-		$data = $misc->getDatabaseAccessor();
-
-		$ops = [];
-		foreach ($_REQUEST['fkey'] as $x => $y) {
-			$ops[$x] = '=';
-		}
-		$query = $data->getSelectSQL($_REQUEST['table'], [], $_REQUEST['fkey'], $ops);
-		$_REQUEST['query'] = $query;
-
-		$fkinfo = $this->getFKInfo();
-
-		$max_pages = 1;
-		// Retrieve page from query.  $max_pages is returned by reference.
-		$rs = $data->browseQuery('SELECT', $_REQUEST['table'], $_REQUEST['query'],
-			null, null, 1, 1, $max_pages);
-
-		echo "<a href=\"\" style=\"display:table-cell;\" class=\"fk_delete\"><img alt=\"[delete]\" src=\"" . $misc->icon('Delete') . "\" /></a>\n";
-		echo "<div style=\"display:table-cell;\">";
-
-		if (is_object($rs) && $rs->recordCount() > 0) {
-			/* we are browsing a referenced table here
-				 * we should show OID if show_oids is true
-				 * so we give true to withOid in functions bellow
-			*/
-
-			echo "<table><tr>";
-			$this->printTableHeaderCells($rs, false, true);
-			echo "</tr>";
-			echo "<tr class=\"data1\">\n";
-			$this->printTableRowCells($rs, $fkinfo, true);
-			echo "</tr>\n";
-			echo "</table>\n";
-		} else {
-			echo $lang['strnodata'];
-		}
-
-		echo "</div>";
-
-		exit;
-	}
+class DisplayController extends BaseController
+{
+    public $_name = 'DisplayController';
+
+    /* Constructor */
+    public function __construct(\Slim\Container $container)
+    {
+        parent::__construct($container);
+
+        // Prevent timeouts on large exports (non-safe mode only)
+        if (!ini_get('safe_mode')) {
+            set_time_limit(0);
+        }
+    }
+
+    public function render()
+    {
+        $conf           = $this->conf;
+        $misc           = $this->misc;
+        $lang           = $this->lang;
+        $plugin_manager = $this->plugin_manager;
+        $data           = $misc->getDatabaseAccessor();
+        $action         = $this->action;
+
+        /* shortcuts: this function exit the script for ajax purpose */
+        if ($action == 'dobrowsefk') {
+            $this->doBrowseFK();
+        }
+
+        $scripts = "<script src=\"/js/display.js\" type=\"text/javascript\"></script>";
+
+        $scripts .= "<script type=\"text/javascript\">\n";
+        $scripts .= "var Display = {\n";
+        $scripts .= "errmsg: '" . str_replace("'", "\'", $lang['strconnectionfail']) . "'\n";
+        $scripts .= "};\n";
+        $scripts .= "</script>\n";
+
+        $footer_template = 'footer.twig';
+        $header_template = 'header.twig';
+
+        ob_start();
+        switch ($action) {
+            case 'editrow':
+                if (isset($_POST['save'])) {
+                    $this->doEditRow(false);
+                } else {
+                    $header_template = 'sqledit_header.twig';
+                    $footer_template = 'sqledit_footer.twig';
+                    $this->doBrowse();
+                }
+
+                break;
+            case 'confeditrow':
+                $this->doEditRow(true);
+                break;
+            case 'delrow':
+                if (isset($_POST['yes'])) {
+                    $this->doDelRow(false);
+                } else {
+                    $header_template = 'sqledit_header.twig';
+                    $footer_template = 'sqledit_footer.twig';
+                    $this->doBrowse();
+                }
+
+                break;
+            case 'confdelrow':
+                $this->doDelRow(true);
+                break;
+            default:
+                $header_template = 'sqledit_header.twig';
+                $footer_template = 'sqledit_footer.twig';
+                $this->doBrowse();
+                break;
+        }
+        $output = ob_get_clean();
+
+        // Set the title based on the subject of the request
+        if (isset($_REQUEST['subject']) && isset($_REQUEST[$_REQUEST['subject']])) {
+            if ($_REQUEST['subject'] == 'table') {
+                $this->printHeader(
+                    $lang['strtables'] . ': ' . $_REQUEST[$_REQUEST['subject']],
+                    $scripts, true, $header_template
+                );
+            } else if ($_REQUEST['subject'] == 'view') {
+                $this->printHeader(
+                    $lang['strviews'] . ': ' . $_REQUEST[$_REQUEST['subject']],
+                    $scripts, true, $header_template
+                );
+            } else if ($_REQUEST['subject'] == 'matview') {
+                $this->printHeader(
+                    'M' . $lang['strviews'] . ': ' . $_REQUEST[$_REQUEST['subject']],
+                    $scripts, true, $header_template
+                );
+            } else if ($_REQUEST['subject'] == 'column') {
+                $this->printHeader(
+                    $lang['strcolumn'] . ': ' . $_REQUEST[$_REQUEST['subject']],
+                    $scripts, true, $header_template
+                );
+            }
+        } else {
+            $this->printHeader($lang['strqueryresults'], $scripts, true, $header_template);
+        }
+
+        $this->printBody();
+
+        echo $output;
+
+        $misc->printFooter(true, $footer_template);
+    }
+
+    /**
+     * Displays requested data
+     */
+    public function doBrowse($msg = '')
+    {
+        $conf           = $this->conf;
+        $misc           = $this->misc;
+        $lang           = $this->lang;
+        $plugin_manager = $this->plugin_manager;
+        $data           = $misc->getDatabaseAccessor();
+
+        $save_history = false;
+        // If current page is not set, default to first page
+        if (!isset($_REQUEST['page'])) {
+            $_REQUEST['page'] = 1;
+        }
+
+        if (!isset($_REQUEST['nohistory'])) {
+            $save_history = true;
+        }
+
+        if (isset($_REQUEST['subject'])) {
+            $subject = $_REQUEST['subject'];
+            if (isset($_REQUEST[$subject])) {
+                $object = $_REQUEST[$subject];
+            }
+
+        } else {
+            $subject = '';
+        }
+
+        $this->printTrail(isset($subject) ? $subject : 'database');
+        $this->printTabs($subject, 'browse');
+
+        /* This code is used when browsing FK in pure-xHTML (without js) */
+        if (isset($_REQUEST['fkey'])) {
+            $ops = [];
+            foreach ($_REQUEST['fkey'] as $x => $y) {
+                $ops[$x] = '=';
+            }
+            $query             = $data->getSelectSQL($_REQUEST['table'], [], $_REQUEST['fkey'], $ops);
+            $_REQUEST['query'] = $query;
+        }
+
+        if (isset($object)) {
+            if (isset($_REQUEST['query'])) {
+                $_SESSION['sqlquery'] = $_REQUEST['query'];
+                $this->printTitle($lang['strselect']);
+                $type = 'SELECT';
+            } else {
+                $type = 'TABLE';
+            }
+        } else {
+            $this->printTitle($lang['strqueryresults']);
+            /*we comes from sql.php, $_SESSION['sqlquery'] has been set there */
+            $type = 'QUERY';
+        }
+
+        $misc->printMsg($msg);
+
+        // If 'sortkey' is not set, default to ''
+        if (!isset($_REQUEST['sortkey'])) {
+            $_REQUEST['sortkey'] = '';
+        }
+
+        // If 'sortdir' is not set, default to ''
+        if (!isset($_REQUEST['sortdir'])) {
+            $_REQUEST['sortdir'] = '';
+        }
+
+        // If 'strings' is not set, default to collapsed
+        if (!isset($_REQUEST['strings'])) {
+            $_REQUEST['strings'] = 'collapsed';
+        }
+
+        // Fetch unique row identifier, if this is a table browse request.
+        if (isset($object)) {
+            $key = $data->getRowIdentifier($object);
+        } else {
+            $key = [];
+        }
+
+        // Set the schema search path
+        if (isset($_REQUEST['search_path'])) {
+            if ($data->setSearchPath(array_map('trim', explode(',', $_REQUEST['search_path']))) != 0) {
+                return;
+            }
+        }
+
+        try {
+            // Retrieve page from query.  $max_pages is returned by reference.
+            $rs = $data->browseQuery($type,
+                isset($object) ? $object : null,
+                isset($_SESSION['sqlquery']) ? $_SESSION['sqlquery'] : null,
+                $_REQUEST['sortkey'], $_REQUEST['sortdir'], $_REQUEST['page'],
+                $conf['max_rows'], $max_pages);
+        } catch (\PHPPgAdmin\ADODB_Exception $e) {
+            return;
+        }
+
+        $fkey_information = $this->getFKInfo();
+
+        // Build strings for GETs in array
+        $_gets = [
+            'server'   => $_REQUEST['server'],
+            'database' => $_REQUEST['database'],
+        ];
+
+        if (isset($_REQUEST['schema'])) {
+            $_gets['schema'] = $_REQUEST['schema'];
+        }
+
+        if (isset($object)) {
+            $_gets[$subject] = $object;
+        }
+
+        if (isset($subject)) {
+            $_gets['subject'] = $subject;
+        }
+
+        if (isset($_REQUEST['query'])) {
+            $_gets['query'] = $_REQUEST['query'];
+        }
+
+        if (isset($_REQUEST['count'])) {
+            $_gets['count'] = $_REQUEST['count'];
+        }
+
+        if (isset($_REQUEST['return'])) {
+            $_gets['return'] = $_REQUEST['return'];
+        }
+
+        if (isset($_REQUEST['search_path'])) {
+            $_gets['search_path'] = $_REQUEST['search_path'];
+        }
+
+        if (isset($_REQUEST['table'])) {
+            $_gets['table'] = $_REQUEST['table'];
+        }
+
+        if (isset($_REQUEST['sortkey'])) {
+            $_gets['sortkey'] = $_REQUEST['sortkey'];
+        }
+
+        if (isset($_REQUEST['sortdir'])) {
+            $_gets['sortdir'] = $_REQUEST['sortdir'];
+        }
+
+        if (isset($_REQUEST['nohistory'])) {
+            $_gets['nohistory'] = $_REQUEST['nohistory'];
+        }
+
+        $_gets['strings'] = $_REQUEST['strings'];
+
+        if ($save_history && is_object($rs) && ($type == 'QUERY')) //{
+        {
+            $misc->saveScriptHistory($_REQUEST['query']);
+        }
+
+        if (isset($_REQUEST['query'])) {
+            $query = $_REQUEST['query'];
+        } else {
+            $query = "SELECT * FROM {$_REQUEST['schema']}";
+            if ($_REQUEST['subject'] == 'matview') {
+                $query = "{$query}.{$_REQUEST['matview']};";
+            } else if ($_REQUEST['subject'] == 'view') {
+                $query = "{$query}.{$_REQUEST['view']};";
+            } else {
+                $query = "{$query}.{$_REQUEST['table']};";
+            }
+        }
+        //$query = isset($_REQUEST['query'])? $_REQUEST['query'] : "select * from {$_REQUEST['schema']}.{$_REQUEST['table']};";
+        $this->prtrace($query);
+        //die(htmlspecialchars($query));
+
+        echo '<form method="POST" id="sqlform" action="' . $_SERVER['REQUEST_URI'] . '">';
+        echo '<textarea width="90%" name="query"  id="query" rows="5" cols="100" resizable="true">';
+
+        echo htmlspecialchars($query);
+        echo '</textarea><br><input type="submit"/></form>';
+
+        if (is_object($rs) && $rs->recordCount() > 0) {
+            // Show page navigation
+            $misc->printPages($_REQUEST['page'], $max_pages, $_gets);
+
+            echo "<table id=\"data\">\n<tr>";
+
+            // Check that the key is actually in the result set.  This can occur for select
+            // operations where the key fields aren't part of the select.  XXX:  We should
+            // be able to support this, somehow.
+            foreach ($key as $v) {
+                // If a key column is not found in the record set, then we
+                // can't use the key.
+                if (!in_array($v, array_keys($rs->fields))) {
+                    $key = [];
+                    break;
+                }
+            }
+
+            $buttons = [
+                'edit'   => [
+                    'content' => $lang['stredit'],
+                    'attr'    => [
+                        'href' => [
+                            'url'     => 'display.php',
+                            'urlvars' => array_merge([
+                                'action'  => 'confeditrow',
+                                'strings' => $_REQUEST['strings'],
+                                'page'    => $_REQUEST['page'],
+                            ], $_gets),
+                        ],
+                    ],
+                ],
+                'delete' => [
+                    'content' => $lang['strdelete'],
+                    'attr'    => [
+                        'href' => [
+                            'url'     => 'display.php',
+                            'urlvars' => array_merge([
+                                'action'  => 'confdelrow',
+                                'strings' => $_REQUEST['strings'],
+                                'page'    => $_REQUEST['page'],
+                            ], $_gets),
+                        ],
+                    ],
+                ],
+            ];
+            $actions = [
+                'actionbuttons' => &$buttons,
+                'place'         => 'display-browse',
+            ];
+            $plugin_manager->do_hook('actionbuttons', $actions);
+
+            foreach (array_keys($actions['actionbuttons']) as $action) {
+                $actions['actionbuttons'][$action]['attr']['href']['urlvars'] = array_merge(
+                    $actions['actionbuttons'][$action]['attr']['href']['urlvars'],
+                    $_gets
+                );
+            }
+
+            $edit_params = isset($actions['actionbuttons']['edit']) ?
+            $actions['actionbuttons']['edit'] : [];
+            $delete_params = isset($actions['actionbuttons']['delete']) ?
+            $actions['actionbuttons']['delete'] : [];
+
+            // Display edit and delete actions if we have a key
+            $colspan = count($buttons);
+            if ($colspan > 0 and count($key) > 0) {
+                echo "<th colspan=\"{$colspan}\" class=\"data\">{$lang['stractions']}</th>\n";
+            }
+
+            /* we show OIDs only if we are in TABLE or SELECT type browsing */
+            $this->printTableHeaderCells($rs, $_gets, isset($object));
+
+            echo "</tr>\n";
+
+            $i = 0;
+            reset($rs->fields);
+            while (!$rs->EOF) {
+                $id = (($i % 2) == 0 ? '1' : '2');
+                echo "<tr class=\"data{$id}\">\n";
+                // Display edit and delete links if we have a key
+                if ($colspan > 0 and count($key) > 0) {
+                    $keys_array = [];
+                    $has_nulls  = false;
+                    foreach ($key as $v) {
+                        if ($rs->fields[$v] === null) {
+                            $has_nulls = true;
+                            break;
+                        }
+                        $keys_array["key[{$v}]"] = $rs->fields[$v];
+                    }
+                    if ($has_nulls) {
+                        echo "<td colspan=\"{$colspan}\">&nbsp;</td>\n";
+                    } else {
+
+                        if (isset($actions['actionbuttons']['edit'])) {
+                            $actions['actionbuttons']['edit']                            = $edit_params;
+                            $actions['actionbuttons']['edit']['attr']['href']['urlvars'] = array_merge(
+                                $actions['actionbuttons']['edit']['attr']['href']['urlvars'],
+                                $keys_array
+                            );
+                        }
+
+                        if (isset($actions['actionbuttons']['delete'])) {
+                            $actions['actionbuttons']['delete']                            = $delete_params;
+                            $actions['actionbuttons']['delete']['attr']['href']['urlvars'] = array_merge(
+                                $actions['actionbuttons']['delete']['attr']['href']['urlvars'],
+                                $keys_array
+                            );
+                        }
+
+                        foreach ($actions['actionbuttons'] as $action) {
+                            echo "<td class=\"opbutton{$id}\">";
+                            $this->printLink($action);
+                            echo "</td>\n";
+                        }
+                    }
+                }
+
+                $this->printTableRowCells($rs, $fkey_information, isset($object));
+
+                echo "</tr>\n";
+                $rs->moveNext();
+                $i++;
+            }
+            echo "</table>\n";
+
+            echo "<p>", $rs->recordCount(), " {$lang['strrows']}</p>\n";
+            // Show page navigation
+            $misc->printPages($_REQUEST['page'], $max_pages, $_gets);
+        } else {
+            echo "<p>{$lang['strnodata']}</p>\n";
+        }
+
+        // Navigation links
+        $navlinks = [];
+
+        $fields = [
+            'server'   => $_REQUEST['server'],
+            'database' => $_REQUEST['database'],
+        ];
+
+        if (isset($_REQUEST['schema'])) {
+            $fields['schema'] = $_REQUEST['schema'];
+        }
+
+        // Return
+        if (isset($_REQUEST['return'])) {
+            $urlvars = $misc->getSubjectParams($_REQUEST['return']);
+
+            $navlinks['back'] = [
+                'attr'    => [
+                    'href' => [
+                        'url'     => $urlvars['url'],
+                        'urlvars' => $urlvars['params'],
+                    ],
+                ],
+                'content' => $lang['strback'],
+            ];
+        }
+
+        // Edit SQL link
+        if ($type == 'QUERY') {
+            $navlinks['edit'] = [
+                'attr'    => [
+                    'href' => [
+                        'url'     => 'database.php',
+                        'urlvars' => array_merge($fields, [
+                            'action'   => 'sql',
+                            'paginate' => 'on',
+                        ]),
+                    ],
+                ],
+                'content' => $lang['streditsql'],
+            ];
+        }
+
+        // Expand/Collapse
+        if ($_REQUEST['strings'] == 'expanded') {
+            $navlinks['collapse'] = [
+                'attr'    => [
+                    'href' => [
+                        'url'     => 'display.php',
+                        'urlvars' => array_merge(
+                            $_gets,
+                            [
+                                'strings' => 'collapsed',
+                                'page'    => $_REQUEST['page'],
+                            ]),
+                    ],
+                ],
+                'content' => $lang['strcollapse'],
+            ];
+        } else {
+            $navlinks['collapse'] = [
+                'attr'    => [
+                    'href' => [
+                        'url'     => 'display.php',
+                        'urlvars' => array_merge(
+                            $_gets,
+                            [
+                                'strings' => 'expanded',
+                                'page'    => $_REQUEST['page'],
+                            ]),
+                    ],
+                ],
+                'content' => $lang['strexpand'],
+            ];
+        }
+
+        // Create view and download
+        if (isset($_REQUEST['query']) && isset($rs) && is_object($rs) && $rs->recordCount() > 0) {
+
+            // Report views don't set a schema, so we need to disable create view in that case
+            if (isset($_REQUEST['schema'])) {
+
+                $navlinks['createview'] = [
+                    'attr'    => [
+                        'href' => [
+                            'url'     => 'views.php',
+                            'urlvars' => array_merge($fields, [
+                                'action'         => 'create',
+                                'formDefinition' => $_REQUEST['query'],
+                            ]),
+                        ],
+                    ],
+                    'content' => $lang['strcreateview'],
+                ];
+            }
+
+            $urlvars = [];
+            if (isset($_REQUEST['search_path'])) {
+                $urlvars['search_path'] = $_REQUEST['search_path'];
+            }
+
+            $navlinks['download'] = [
+                'attr'    => [
+                    'href' => [
+                        'url'     => 'dataexport.php',
+                        'urlvars' => array_merge($fields, $urlvars),
+                    ],
+                ],
+                'content' => $lang['strdownload'],
+            ];
+        }
+
+        // Insert
+        if (isset($object) && (isset($subject) && $subject == 'table')) {
+            $navlinks['insert'] = [
+                'attr'    => [
+                    'href' => [
+                        'url'     => 'tables.php',
+                        'urlvars' => array_merge($fields, [
+                            'action' => 'confinsertrow',
+                            'table'  => $object,
+                        ]),
+                    ],
+                ],
+                'content' => $lang['strinsert'],
+            ];
+        }
+
+        // Refresh
+        $navlinks['refresh'] = [
+            'attr'    => [
+                'href' => [
+                    'url'     => 'display.php',
+                    'urlvars' => array_merge(
+                        $_gets,
+                        [
+                            'strings' => $_REQUEST['strings'],
+                            'page'    => $_REQUEST['page'],
+                        ]),
+                ],
+            ],
+            'content' => $lang['strrefresh'],
+        ];
+
+        $this->printNavLinks($navlinks, 'display-browse', get_defined_vars());
+    }
+
+    /**
+     * Show confirmation of edit and perform actual update
+     */
+    public function doEditRow($confirm, $msg = '')
+    {
+        $conf = $this->conf;
+        $misc = $this->misc;
+        $lang = $this->lang;
+        $data = $misc->getDatabaseAccessor();
+
+        if (is_array($_REQUEST['key'])) {
+            $key = $_REQUEST['key'];
+        } else {
+            $key = unserialize(urldecode($_REQUEST['key']));
+        }
+
+        if ($confirm) {
+            $this->printTrail($_REQUEST['subject']);
+            $this->printTitle($lang['streditrow']);
+            $misc->printMsg($msg);
+
+            $attrs = $data->getTableAttributes($_REQUEST['table']);
+            $rs    = $data->browseRow($_REQUEST['table'], $key);
+
+            if (($conf['autocomplete'] != 'disable')) {
+                $fksprops = $misc->getAutocompleteFKProperties($_REQUEST['table']);
+                if ($fksprops !== false) {
+                    echo $fksprops['code'];
+                }
+
+            } else {
+                $fksprops = false;
+            }
+
+            echo "<form action=\"/src/views/display.php\" method=\"post\" id=\"ac_form\">\n";
+            $elements = 0;
+            $error    = true;
+            if ($rs->recordCount() == 1 && $attrs->recordCount() > 0) {
+                echo "<table>\n";
+
+                // Output table header
+                echo "<tr><th class=\"data\">{$lang['strcolumn']}</th><th class=\"data\">{$lang['strtype']}</th>";
+                echo "<th class=\"data\">{$lang['strformat']}</th>\n";
+                echo "<th class=\"data\">{$lang['strnull']}</th><th class=\"data\">{$lang['strvalue']}</th></tr>";
+
+                $i = 0;
+                while (!$attrs->EOF) {
+
+                    $attrs->fields['attnotnull'] = $data->phpBool($attrs->fields['attnotnull']);
+                    $id                          = (($i % 2) == 0 ? '1' : '2');
+
+                    // Initialise variables
+                    if (!isset($_REQUEST['format'][$attrs->fields['attname']])) {
+                        $_REQUEST['format'][$attrs->fields['attname']] = 'VALUE';
+                    }
+
+                    echo "<tr class=\"data{$id}\">\n";
+                    echo "<td style=\"white-space:nowrap;\">", $misc->printVal($attrs->fields['attname']), "</td>";
+                    echo "<td style=\"white-space:nowrap;\">\n";
+                    echo $misc->printVal($data->formatType($attrs->fields['type'], $attrs->fields['atttypmod']));
+                    echo "<input type=\"hidden\" name=\"types[", htmlspecialchars($attrs->fields['attname']), "]\" value=\"",
+                    htmlspecialchars($attrs->fields['type']), "\" /></td>";
+                    $elements++;
+                    echo "<td style=\"white-space:nowrap;\">\n";
+                    echo "<select name=\"format[", htmlspecialchars($attrs->fields['attname']), "]\">\n";
+                    echo "<option value=\"VALUE\"", ($_REQUEST['format'][$attrs->fields['attname']] == 'VALUE') ? ' selected="selected"' : '', ">{$lang['strvalue']}</option>\n";
+                    echo "<option value=\"EXPRESSION\"", ($_REQUEST['format'][$attrs->fields['attname']] == 'EXPRESSION') ? ' selected="selected"' : '', ">{$lang['strexpression']}</option>\n";
+                    echo "</select>\n</td>\n";
+                    $elements++;
+                    echo "<td style=\"white-space:nowrap;\">";
+                    // Output null box if the column allows nulls (doesn't look at CHECKs or ASSERTIONS)
+                    if (!$attrs->fields['attnotnull']) {
+                        // Set initial null values
+                        if ($_REQUEST['action'] == 'confeditrow' && $rs->fields[$attrs->fields['attname']] === null) {
+                            $_REQUEST['nulls'][$attrs->fields['attname']] = 'on';
+                        }
+                        echo "<label><span><input type=\"checkbox\" name=\"nulls[{$attrs->fields['attname']}]\"",
+                        isset($_REQUEST['nulls'][$attrs->fields['attname']]) ? ' checked="checked"' : '', " /></span></label></td>\n";
+                        $elements++;
+                    } else {
+                        echo "&nbsp;</td>";
+                    }
+
+                    echo "<td id=\"row_att_{$attrs->fields['attnum']}\" style=\"white-space:nowrap;\">";
+
+                    $extras = [];
+
+                    // If the column allows nulls, then we put a JavaScript action on the data field to unset the
+                    // NULL checkbox as soon as anything is entered in the field.  We use the $elements variable to
+                    // keep track of which element offset we're up to.  We can't refer to the null checkbox by name
+                    // as it contains '[' and ']' characters.
+                    if (!$attrs->fields['attnotnull']) {
+                        $extras['onChange'] = 'elements[' . ($elements - 1) . '].checked = false;';
+                    }
+
+                    if (($fksprops !== false) && isset($fksprops['byfield'][$attrs->fields['attnum']])) {
+                        $extras['id']           = "attr_{$attrs->fields['attnum']}";
+                        $extras['autocomplete'] = 'off';
+                    }
+
+                    echo $data->printField("values[{$attrs->fields['attname']}]", $rs->fields[$attrs->fields['attname']], $attrs->fields['type'], $extras);
+
+                    echo "</td>";
+                    $elements++;
+                    echo "</tr>\n";
+                    $i++;
+                    $attrs->moveNext();
+                }
+                echo "</table>\n";
+
+                $error = false;
+            } elseif ($rs->recordCount() != 1) {
+                echo "<p>{$lang['strrownotunique']}</p>\n";
+            } else {
+                echo "<p>{$lang['strinvalidparam']}</p>\n";
+            }
+
+            echo "<input type=\"hidden\" name=\"action\" value=\"editrow\" />\n";
+            echo $misc->form;
+            if (isset($_REQUEST['table'])) {
+                echo "<input type=\"hidden\" name=\"table\" value=\"", htmlspecialchars($_REQUEST['table']), "\" />\n";
+            }
+
+            if (isset($_REQUEST['subject'])) {
+                echo "<input type=\"hidden\" name=\"subject\" value=\"", htmlspecialchars($_REQUEST['subject']), "\" />\n";
+            }
+
+            if (isset($_REQUEST['query'])) {
+                echo "<input type=\"hidden\" name=\"query\" value=\"", htmlspecialchars($_REQUEST['query']), "\" />\n";
+            }
+
+            if (isset($_REQUEST['count'])) {
+                echo "<input type=\"hidden\" name=\"count\" value=\"", htmlspecialchars($_REQUEST['count']), "\" />\n";
+            }
+
+            if (isset($_REQUEST['return'])) {
+                echo "<input type=\"hidden\" name=\"return\" value=\"", htmlspecialchars($_REQUEST['return']), "\" />\n";
+            }
+
+            echo "<input type=\"hidden\" name=\"page\" value=\"", htmlspecialchars($_REQUEST['page']), "\" />\n";
+            echo "<input type=\"hidden\" name=\"sortkey\" value=\"", htmlspecialchars($_REQUEST['sortkey']), "\" />\n";
+            echo "<input type=\"hidden\" name=\"sortdir\" value=\"", htmlspecialchars($_REQUEST['sortdir']), "\" />\n";
+            echo "<input type=\"hidden\" name=\"strings\" value=\"", htmlspecialchars($_REQUEST['strings']), "\" />\n";
+            echo "<input type=\"hidden\" name=\"key\" value=\"", htmlspecialchars(urlencode(serialize($key))), "\" />\n";
+            echo "<p>";
+            if (!$error) {
+                echo "<input type=\"submit\" name=\"save\" accesskey=\"r\" value=\"{$lang['strsave']}\" />\n";
+            }
+
+            echo "<input type=\"submit\" name=\"cancel\" value=\"{$lang['strcancel']}\" />\n";
+
+            if ($fksprops !== false) {
+                if ($conf['autocomplete'] != 'default off') {
+                    echo "<input type=\"checkbox\" id=\"no_ac\" value=\"1\" checked=\"checked\" /><label for=\"no_ac\">{$lang['strac']}</label>\n";
+                } else {
+                    echo "<input type=\"checkbox\" id=\"no_ac\" value=\"0\" /><label for=\"no_ac\">{$lang['strac']}</label>\n";
+                }
+
+            }
+
+            echo "</p>\n";
+            echo "</form>\n";
+        } else {
+            if (!isset($_POST['values'])) {
+                $_POST['values'] = [];
+            }
+
+            if (!isset($_POST['nulls'])) {
+                $_POST['nulls'] = [];
+            }
+
+            $status = $data->editRow($_POST['table'], $_POST['values'], $_POST['nulls'],
+                $_POST['format'], $_POST['types'], $key);
+            if ($status == 0) {
+                $this->doBrowse($lang['strrowupdated']);
+            } elseif ($status == -2) {
+                $this->doEditRow(true, $lang['strrownotunique']);
+            } else {
+                $this->doEditRow(true, $lang['strrowupdatedbad']);
+            }
+
+        }
+
+    }
+
+    /**
+     * Show confirmation of drop and perform actual drop
+     */
+    public function doDelRow($confirm)
+    {
+        $conf = $this->conf;
+        $misc = $this->misc;
+        $lang = $this->lang;
+        $data = $misc->getDatabaseAccessor();
+
+        if ($confirm) {
+            $this->printTrail($_REQUEST['subject']);
+            $this->printTitle($lang['strdeleterow']);
+
+            $rs = $data->browseRow($_REQUEST['table'], $_REQUEST['key']);
+
+            echo "<form action=\"/src/views/display.php\" method=\"post\">\n";
+            echo $misc->form;
+
+            if ($rs->recordCount() == 1) {
+                echo "<p>{$lang['strconfdeleterow']}</p>\n";
+
+                $fkinfo = [];
+                echo "<table><tr>";
+                $this->printTableHeaderCells($rs, false, true);
+                echo "</tr>";
+                echo "<tr class=\"data1\">\n";
+                $this->printTableRowCells($rs, $fkinfo, true);
+                echo "</tr>\n";
+                echo "</table>\n";
+                echo "<br />\n";
+
+                echo "<input type=\"hidden\" name=\"action\" value=\"delrow\" />\n";
+                echo "<input type=\"submit\" name=\"yes\" value=\"{$lang['stryes']}\" />\n";
+                echo "<input type=\"submit\" name=\"no\" value=\"{$lang['strno']}\" />\n";
+            } elseif ($rs->recordCount() != 1) {
+                echo "<p>{$lang['strrownotunique']}</p>\n";
+                echo "<input type=\"submit\" name=\"cancel\" value=\"{$lang['strcancel']}\" />\n";
+            } else {
+                echo "<p>{$lang['strinvalidparam']}</p>\n";
+                echo "<input type=\"submit\" name=\"cancel\" value=\"{$lang['strcancel']}\" />\n";
+            }
+            if (isset($_REQUEST['table'])) {
+                echo "<input type=\"hidden\" name=\"table\" value=\"", htmlspecialchars($_REQUEST['table']), "\" />\n";
+            }
+
+            if (isset($_REQUEST['subject'])) {
+                echo "<input type=\"hidden\" name=\"subject\" value=\"", htmlspecialchars($_REQUEST['subject']), "\" />\n";
+            }
+
+            if (isset($_REQUEST['query'])) {
+                echo "<input type=\"hidden\" name=\"query\" value=\"", htmlspecialchars($_REQUEST['query']), "\" />\n";
+            }
+
+            if (isset($_REQUEST['count'])) {
+                echo "<input type=\"hidden\" name=\"count\" value=\"", htmlspecialchars($_REQUEST['count']), "\" />\n";
+            }
+
+            if (isset($_REQUEST['return'])) {
+                echo "<input type=\"hidden\" name=\"return\" value=\"", htmlspecialchars($_REQUEST['return']), "\" />\n";
+            }
+
+            echo "<input type=\"hidden\" name=\"page\" value=\"", htmlspecialchars($_REQUEST['page']), "\" />\n";
+            echo "<input type=\"hidden\" name=\"sortkey\" value=\"", htmlspecialchars($_REQUEST['sortkey']), "\" />\n";
+            echo "<input type=\"hidden\" name=\"sortdir\" value=\"", htmlspecialchars($_REQUEST['sortdir']), "\" />\n";
+            echo "<input type=\"hidden\" name=\"strings\" value=\"", htmlspecialchars($_REQUEST['strings']), "\" />\n";
+            echo "<input type=\"hidden\" name=\"key\" value=\"", htmlspecialchars(urlencode(serialize($_REQUEST['key']))), "\" />\n";
+            echo "</form>\n";
+        } else {
+            $status = $data->deleteRow($_POST['table'], unserialize(urldecode($_POST['key'])));
+            if ($status == 0) {
+                $this->doBrowse($lang['strrowdeleted']);
+            } elseif ($status == -2) {
+                $this->doBrowse($lang['strrownotunique']);
+            } else {
+                $this->doBrowse($lang['strrowdeletedbad']);
+            }
+
+        }
+
+    }
+
+    /**
+     * build & return the FK information data structure
+     * used when deciding if a field should have a FK link or not
+     * @return [type] [description]
+     */
+    public function &getFKInfo()
+    {
+        $conf = $this->conf;
+        $misc = $this->misc;
+        $lang = $this->lang;
+        $data = $misc->getDatabaseAccessor();
+
+        // Get the foreign key(s) information from the current table
+        $fkey_information = ['byconstr' => [], 'byfield' => []];
+
+        if (isset($_REQUEST['table'])) {
+            $constraints = $data->getConstraintsWithFields($_REQUEST['table']);
+            if ($constraints->recordCount() > 0) {
+
+                $fkey_information['common_url'] = $misc->getHREF('schema') . '&amp;subject=table';
+
+                /* build the FK constraints data structure */
+                while (!$constraints->EOF) {
+                    $constr = &$constraints->fields;
+                    if ($constr['contype'] == 'f') {
+
+                        if (!isset($fkey_information['byconstr'][$constr['conid']])) {
+                            $fkey_information['byconstr'][$constr['conid']] = [
+                                'url_data' => 'table=' . urlencode($constr['f_table']) . '&amp;schema=' . urlencode($constr['f_schema']),
+                                'fkeys'    => [],
+                                'consrc'   => $constr['consrc'],
+                            ];
+                        }
+
+                        $fkey_information['byconstr'][$constr['conid']]['fkeys'][$constr['p_field']] = $constr['f_field'];
+
+                        if (!isset($fkey_information['byfield'][$constr['p_field']])) {
+                            $fkey_information['byfield'][$constr['p_field']] = [];
+                        }
+
+                        $fkey_information['byfield'][$constr['p_field']][] = $constr['conid'];
+                    }
+                    $constraints->moveNext();
+                }
+            }
+        }
+
+        return $fkey_information;
+    }
+
+    /**
+     * Print table header cells
+     * @param $args - associative array for sort link parameters
+     *
+     */
+    public function printTableHeaderCells(&$rs, $args, $withOid)
+    {
+        $conf = $this->conf;
+        $misc = $this->misc;
+        $lang = $this->lang;
+        $data = $misc->getDatabaseAccessor();
+        $j    = 0;
+
+        foreach ($rs->fields as $k => $v) {
+
+            if (($k === $data->id) && (!($withOid && $conf['show_oids']))) {
+                $j++;
+                continue;
+            }
+            $finfo = $rs->fetchField($j);
+
+            if ($args === false) {
+                echo "<th class=\"data\">", $misc->printVal($finfo->name), "</th>\n";
+            } else {
+                $args['page']    = $_REQUEST['page'];
+                $args['sortkey'] = $j + 1;
+                // Sort direction opposite to current direction, unless it's currently ''
+                $args['sortdir'] = (
+                    $_REQUEST['sortdir'] == 'asc'
+                    and $_REQUEST['sortkey'] == ($j + 1)
+                ) ? 'desc' : 'asc';
+
+                $sortLink = http_build_query($args);
+
+                echo "<th class=\"data\"><a href=\"?{$sortLink}\">"
+                , $misc->printVal($finfo->name);
+                if ($_REQUEST['sortkey'] == ($j + 1)) {
+                    if ($_REQUEST['sortdir'] == 'asc') {
+                        echo '<img src="' . $misc->icon('RaiseArgument') . '" alt="asc">';
+                    } else {
+                        echo '<img src="' . $misc->icon('LowerArgument') . '" alt="desc">';
+                    }
+
+                }
+                echo "</a></th>\n";
+            }
+            $j++;
+        }
+
+        reset($rs->fields);
+    }
+
+    /* Print data-row cells */
+    public function printTableRowCells(&$rs, &$fkey_information, $withOid)
+    {
+        $conf = $this->conf;
+        $misc = $this->misc;
+        $lang = $this->lang;
+        $data = $misc->getDatabaseAccessor();
+        $j    = 0;
+
+        if (!isset($_REQUEST['strings'])) {
+            $_REQUEST['strings'] = 'collapsed';
+        }
+
+        foreach ($rs->fields as $k => $v) {
+            $finfo = $rs->fetchField($j++);
+
+            if (($k === $data->id) && (!($withOid && $conf['show_oids']))) {
+                continue;
+            } elseif ($v !== null && $v == '') {
+                echo "<td>&nbsp;</td>";
+            } else {
+                echo "<td style=\"white-space:nowrap;\">";
+
+                if (($v !== null) && isset($fkey_information['byfield'][$k])) {
+                    foreach ($fkey_information['byfield'][$k] as $conid) {
+
+                        $query_params = $fkey_information['byconstr'][$conid]['url_data'];
+
+                        foreach ($fkey_information['byconstr'][$conid]['fkeys'] as $p_field => $f_field) {
+                            $query_params .= '&amp;' . urlencode("fkey[{$f_field}]") . '=' . urlencode($rs->fields[$p_field]);
+                        }
+
+                        /* $fkey_information['common_url'] is already urlencoded */
+                        $query_params .= '&amp;' . $fkey_information['common_url'];
+                        echo "<div style=\"display:inline-block;\">";
+                        echo "<a class=\"fk fk_" . htmlentities($conid, ENT_QUOTES, 'UTF-8') . "\" href=\"display.php?{$query_params}\">";
+                        echo "<img src=\"" . $misc->icon('ForeignKey') . "\" style=\"vertical-align:middle;\" alt=\"[fk]\" title=\""
+                        . htmlentities($fkey_information['byconstr'][$conid]['consrc'], ENT_QUOTES, 'UTF-8')
+                            . "\" />";
+                        echo "</a>";
+                        echo "</div>";
+                    }
+                    echo $misc->printVal($v, $finfo->type, ['null' => true, 'clip' => ($_REQUEST['strings'] == 'collapsed'), 'class' => 'fk_value']);
+                } else {
+                    echo $misc->printVal($v, $finfo->type, ['null' => true, 'clip' => ($_REQUEST['strings'] == 'collapsed')]);
+                }
+                echo "</td>";
+            }
+        }
+    }
+
+    /* Print the FK row, used in ajax requests */
+    public function doBrowseFK()
+    {
+        $conf = $this->conf;
+        $misc = $this->misc;
+        $lang = $this->lang;
+        $data = $misc->getDatabaseAccessor();
+
+        $ops = [];
+        foreach ($_REQUEST['fkey'] as $x => $y) {
+            $ops[$x] = '=';
+        }
+        $query             = $data->getSelectSQL($_REQUEST['table'], [], $_REQUEST['fkey'], $ops);
+        $_REQUEST['query'] = $query;
+
+        $fkinfo = $this->getFKInfo();
+
+        $max_pages = 1;
+        // Retrieve page from query.  $max_pages is returned by reference.
+        $rs = $data->browseQuery('SELECT', $_REQUEST['table'], $_REQUEST['query'],
+            null, null, 1, 1, $max_pages);
+
+        echo "<a href=\"\" style=\"display:table-cell;\" class=\"fk_delete\"><img alt=\"[delete]\" src=\"" . $misc->icon('Delete') . "\" /></a>\n";
+        echo "<div style=\"display:table-cell;\">";
+
+        if (is_object($rs) && $rs->recordCount() > 0) {
+            /* we are browsing a referenced table here
+             * we should show OID if show_oids is true
+             * so we give true to withOid in functions bellow
+             */
+
+            echo "<table><tr>";
+            $this->printTableHeaderCells($rs, false, true);
+            echo "</tr>";
+            echo "<tr class=\"data1\">\n";
+            $this->printTableRowCells($rs, $fkinfo, true);
+            echo "</tr>\n";
+            echo "</table>\n";
+        } else {
+            echo $lang['strnodata'];
+        }
+
+        echo "</div>";
+
+        exit;
+    }
 
 }

--- a/src/help/PostgresDoc80.php
+++ b/src/help/PostgresDoc80.php
@@ -6,7 +6,7 @@
  * $Id: PostgresDoc80.php,v 1.5 2005/02/16 10:27:44 jollytoad Exp $
  */
 
-include BASE_PATH . '/help/PostgresDoc74.php';
+include BASE_PATH . '/src/help/PostgresDoc74.php';
 
 $this->help_page['pg.column.add'][0]  = 'ddl-alter.html#AEN2217';
 $this->help_page['pg.column.drop'][0] = 'ddl-alter.html#AEN2226';

--- a/src/help/PostgresDoc81.php
+++ b/src/help/PostgresDoc81.php
@@ -6,7 +6,7 @@
  * $Id: PostgresDoc81.php,v 1.3 2006/12/28 04:26:55 xzilla Exp $
  */
 
-include BASE_PATH . '/help/PostgresDoc80.php';
+include BASE_PATH . '/src/help/PostgresDoc80.php';
 
 $this->help_page['pg.role']        = 'user-manag.html';
 $this->help_page['pg.role.create'] = ['sql-createrole.html', 'user-manag.html#DATABASE-ROLES'];

--- a/src/help/PostgresDoc82.php
+++ b/src/help/PostgresDoc82.php
@@ -6,4 +6,4 @@
  * $Id: PostgresDoc82.php,v 1.3 2007/11/30 15:27:26 soranzo Exp $
  */
 
-include BASE_PATH . '/help/PostgresDoc81.php';
+include BASE_PATH . '/src/help/PostgresDoc81.php';

--- a/src/help/PostgresDoc83.php
+++ b/src/help/PostgresDoc83.php
@@ -6,7 +6,7 @@
  * $Id: PostgresDoc83.php,v 1.3 2008/03/17 21:35:48 ioguix Exp $
  */
 
-include BASE_PATH . '/help/PostgresDoc82.php';
+include BASE_PATH . '/src/help/PostgresDoc82.php';
 
 $this->help_page['pg.fts'] = 'textsearch.html';
 

--- a/src/help/PostgresDoc84.php
+++ b/src/help/PostgresDoc84.php
@@ -6,4 +6,4 @@
  * $Id: PostgresDoc84.php,v 1.3 2008/11/18 21:35:48 ioguix Exp $
  */
 
-include BASE_PATH . '/help/PostgresDoc83.php';
+include BASE_PATH . '/src/help/PostgresDoc83.php';

--- a/src/help/PostgresDoc90.php
+++ b/src/help/PostgresDoc90.php
@@ -6,4 +6,4 @@
  * $Id: PostgresDoc84.php,v 1.3 2008/11/18 21:35:48 ioguix Exp $
  */
 
-include BASE_PATH . '/help/PostgresDoc84.php';
+include BASE_PATH . '/src/help/PostgresDoc84.php';

--- a/src/help/PostgresDoc91.php
+++ b/src/help/PostgresDoc91.php
@@ -6,4 +6,4 @@
  * $Id: PostgresDoc84.php,v 1.3 2008/11/18 21:35:48 ioguix Exp $
  */
 
-include BASE_PATH . '/help/PostgresDoc90.php';
+include BASE_PATH . '/src/help/PostgresDoc90.php';

--- a/src/help/PostgresDoc92.php
+++ b/src/help/PostgresDoc92.php
@@ -6,4 +6,4 @@
  * $Id: PostgresDoc84.php,v 1.3 2008/11/18 21:35:48 ioguix Exp $
  */
 
-include BASE_PATH . '/help/PostgresDoc91.php';
+include BASE_PATH . '/src/help/PostgresDoc91.php';

--- a/src/help/PostgresDoc93.php
+++ b/src/help/PostgresDoc93.php
@@ -6,4 +6,4 @@
  * $Id: PostgresDoc84.php,v 1.3 2008/11/18 21:35:48 ioguix Exp $
  */
 
-include BASE_PATH . '/help/PostgresDoc92.php';
+include BASE_PATH . '/src/help/PostgresDoc92.php';

--- a/src/help/PostgresDoc94.php
+++ b/src/help/PostgresDoc94.php
@@ -6,4 +6,4 @@
  * $Id: PostgresDoc84.php,v 1.3 2008/11/18 21:35:48 ioguix Exp $
  */
 
-include BASE_PATH . '/help/PostgresDoc93.php';
+include BASE_PATH . '/src/help/PostgresDoc93.php';

--- a/src/help/PostgresDoc95.php
+++ b/src/help/PostgresDoc95.php
@@ -5,6 +5,6 @@
  *
  */
 
-include BASE_PATH . '/help/PostgresDoc94.php';
+include BASE_PATH . '/src/help/PostgresDoc94.php';
 
 $this->help_page['pg.matview'] = 'sql-creatematerializedview.html';

--- a/src/help/PostgresDoc96.php
+++ b/src/help/PostgresDoc96.php
@@ -5,4 +5,4 @@
  *
  */
 
-include BASE_PATH . '/help/PostgresDoc95.php';
+include BASE_PATH . '/src/help/PostgresDoc95.php';

--- a/src/lib.inc.php
+++ b/src/lib.inc.php
@@ -13,7 +13,16 @@ DEFINE('THEME_PATH', BASE_PATH . "/src/themes");
 ini_set('arg_separator.output', '&amp;');
 
 ini_set('error_log', BASE_PATH . '/temp/logs/phppga.php_error.log');
-$debugmode = true;
+
+// Check to see if the configuration file exists, if not, explain
+if (file_exists(BASE_PATH . '/config.inc.php')) {
+	$conf = [];
+	include BASE_PATH . '/config.inc.php';
+} else {
+	die('Configuration error: Copy config.inc.php-dist to config.inc.php and edit appropriately.');
+
+}
+$debugmode = (!isset($conf['debugmode'])) ? false : $conf['debugmode'];
 
 if ($debugmode) {
 	ini_set('display_errors', 1);
@@ -36,6 +45,11 @@ if (!ini_get('session.auto_start')) {
 	session_name('PPA_ID');
 	session_start();
 }
+\Kint::$enabled_mode = ($debugmode);
+
+\Kint::dump($_SERVER);
+die();
+
 $handler = PhpConsole\Handler::getInstance();
 $handler->start(); // initialize handlers*/
 PhpConsole\Helper::register(); // it will register global PC class
@@ -74,17 +88,8 @@ $app = new \Slim\App($config);
 // Fetch DI Container
 $container = $app->getContainer();
 
-\Kint::$enabled_mode = ($debugmode);
+$container['conf'] = function ($c) use ($conf) {
 
-$container['conf'] = function ($c) {
-// Check to see if the configuration file exists, if not, explain
-	if (file_exists(BASE_PATH . '/config.inc.php')) {
-		$conf = [];
-		include BASE_PATH . '/config.inc.php';
-	} else {
-		die('Configuration error: Copy config.inc.php-dist to config.inc.php and edit appropriately.');
-
-	}
 	// Plugins are removed
 	$conf['plugins'] = [];
 

--- a/src/xhtml/HTMLNavbarController.php
+++ b/src/xhtml/HTMLNavbarController.php
@@ -6,285 +6,291 @@ namespace PHPPgAdmin\XHtml;
  * Class to render tables. Formerly part of Misc.php
  *
  */
-class HTMLNavbarController extends HTMLController {
-	public $_name = 'HTMLNavbarController';
+class HTMLNavbarController extends HTMLController
+{
+    public $_name = 'HTMLNavbarController';
 
-	/**
-	 * Display a bread crumb trail.
-	 * @param  $do_print true to echo, false to return html
-	 */
-	function printTrail($trail = [], $do_print = true) {
-		$lang = $this->lang;
-		$misc = $this->misc;
+    /**
+     * Display a bread crumb trail.
+     * @param  $do_print true to echo, false to return html
+     */
+    public function printTrail($trail = [], $do_print = true)
+    {
+        $lang = $this->lang;
+        $misc = $this->misc;
 
-		$trail_html = $this->printTopbar(false);
+        $trail_html = $this->printTopbar(false);
 
-		if (is_string($trail)) {
-			$trail = $this->getTrail($trail);
-		}
+        if (is_string($trail)) {
+            $trail = $this->getTrail($trail);
+        }
 
-		$trail_html .= '<div class="trail" data-controller="' . $this->controller_name . '"><table><tr>';
+        $trail_html .= '<div class="trail" data-controller="' . $this->controller_name . '"><table><tr>';
 
-		foreach ($trail as $crumb) {
-			$trail_html .= "<td class=\"crumb\">";
-			$crumblink = "<a";
+        foreach ($trail as $crumb) {
+            $trail_html .= "<td class=\"crumb\">";
+            $crumblink = "<a";
 
-			if (isset($crumb['url'])) {
-				$crumblink .= " href=\"{$crumb['url']}\"";
-			}
+            if (isset($crumb['url'])) {
+                $crumblink .= " href=\"{$crumb['url']}\"";
+            }
 
-			if (isset($crumb['title'])) {
-				$crumblink .= " title=\"{$crumb['title']}\"";
-			}
+            if (isset($crumb['title'])) {
+                $crumblink .= " title=\"{$crumb['title']}\"";
+            }
 
-			$crumblink .= ">";
+            $crumblink .= ">";
 
-			if (isset($crumb['title'])) {
-				$iconalt = $crumb['title'];
-			} else {
-				$iconalt = 'Database Root';
-			}
+            if (isset($crumb['title'])) {
+                $iconalt = $crumb['title'];
+            } else {
+                $iconalt = 'Database Root';
+            }
 
-			if (isset($crumb['icon']) && $icon = $misc->icon($crumb['icon'])) {
-				$crumblink .= "<span class=\"icon\"><img src=\"{$icon}\" alt=\"{$iconalt}\" /></span>";
-			}
+            if (isset($crumb['icon']) && $icon = $misc->icon($crumb['icon'])) {
+                $crumblink .= "<span class=\"icon\"><img src=\"{$icon}\" alt=\"{$iconalt}\" /></span>";
+            }
 
-			$crumblink .= "<span class=\"label\">" . htmlspecialchars($crumb['text']) . "</span></a>";
+            $crumblink .= "<span class=\"label\">" . htmlspecialchars($crumb['text']) . "</span></a>";
 
-			if (isset($crumb['help'])) {
-				$trail_html .= $misc->printHelp($crumblink, $crumb['help'], false);
-			} else {
-				$trail_html .= $crumblink;
-			}
+            if (isset($crumb['help'])) {
+                $trail_html .= $misc->printHelp($crumblink, $crumb['help'], false);
+            } else {
+                $trail_html .= $crumblink;
+            }
 
-			$trail_html .= "{$lang['strseparator']}";
-			$trail_html .= "</td>";
-		}
+            $trail_html .= "{$lang['strseparator']}";
+            $trail_html .= "</td>";
+        }
 
-		$trail_html .= "</tr></table></div>\n";
-		if ($do_print) {
-			echo $trail_html;
-		} else {
-			return $trail_html;
-		}
-	}
+        $trail_html .= "</tr></table></div>\n";
+        if ($do_print) {
+            echo $trail_html;
+        } else {
+            return $trail_html;
+        }
+    }
 
-	/**
-	 * Display the navlinks
-	 *
-	 * @param $navlinks - An array with the the attributes and values that will be shown. See printLinksList for array format.
-	 * @param $place - Place where the $navlinks are displayed. Like 'display-browse', where 'display' is the file (display.php)
-	 * @param $env - Associative array of defined variables in the scope of the caller.
-	 *               Allows to give some environnement details to plugins.
-	 * and 'browse' is the place inside that code (doBrowse).
-	 * @param bool $do_print if true, print html, if false, return html
-	 */
-	function printNavLinks($navlinks, $place, $env = [], $do_print = true) {
-		$plugin_manager = $this->plugin_manager;
+    /**
+     * Display the navlinks
+     *
+     * @param $navlinks - An array with the the attributes and values that will be shown. See printLinksList for array format.
+     * @param $place - Place where the $navlinks are displayed. Like 'display-browse', where 'display' is the file (display.php)
+     * @param $env - Associative array of defined variables in the scope of the caller.
+     *               Allows to give some environnement details to plugins.
+     * and 'browse' is the place inside that code (doBrowse).
+     * @param bool $do_print if true, print html, if false, return html
+     */
+    public function printNavLinks($navlinks, $place, $env = [], $do_print = true)
+    {
+        $plugin_manager = $this->plugin_manager;
 
-		// Navlinks hook's place
-		$plugin_functions_parameters = [
-			'navlinks' => &$navlinks,
-			'place' => $place,
-			'env' => $env,
-		];
-		$plugin_manager->do_hook('navlinks', $plugin_functions_parameters);
+        // Navlinks hook's place
+        $plugin_functions_parameters = [
+            'navlinks' => &$navlinks,
+            'place'    => $place,
+            'env'      => $env,
+        ];
+        $plugin_manager->do_hook('navlinks', $plugin_functions_parameters);
 
-		if (count($navlinks) > 0) {
-			if ($do_print) {
-				$this->printLinksList($navlinks, 'navlink');
-			} else {
-				return $this->printLinksList($navlinks, 'navlink', false);
-			}
+        if (count($navlinks) > 0) {
+            if ($do_print) {
+                $this->printLinksList($navlinks, 'navlink');
+            } else {
+                return $this->printLinksList($navlinks, 'navlink', false);
+            }
 
-		}
-	}
+        }
+    }
 
-	/**
-	 * Display navigation tabs
-	 * @param $tabs The name of current section (Ex: intro, server, ...), or an array with tabs (Ex: sqledit.php doFind function)
-	 * @param $activetab The name of the tab to be highlighted.
-	 * @param  $print if false, return html
-	 */
-	function printTabs($tabs, $activetab, $do_print = true) {
+    /**
+     * Display navigation tabs
+     * @param $tabs The name of current section (Ex: intro, server, ...), or an array with tabs (Ex: sqledit.php doFind function)
+     * @param $activetab The name of the tab to be highlighted.
+     * @param  $print if false, return html
+     */
+    public function printTabs($tabs, $activetab, $do_print = true)
+    {
 
-		$lang = $this->lang;
-		$misc = $this->misc;
-		$data = $misc->getDatabaseAccessor();
+        $lang = $this->lang;
+        $misc = $this->misc;
+        $data = $misc->getDatabaseAccessor();
 
-		if (is_string($tabs)) {
-			$_SESSION['webdbLastTab'][$tabs] = $activetab;
-			$tabs = $misc->getNavTabs($tabs);
-		}
-		$tabs_html = '';
-		if (count($tabs) > 0) {
+        if (is_string($tabs)) {
+            $_SESSION['webdbLastTab'][$tabs] = $activetab;
+            $tabs                            = $misc->getNavTabs($tabs);
+        }
+        $tabs_html = '';
+        if (count($tabs) > 0) {
 
-			$tabs_html .= '<table class="tabs" data-controller="' . $this->controller_name . '"><tr>' . "\n";
+            $tabs_html .= '<table class="tabs" data-controller="' . $this->controller_name . '"><tr>' . "\n";
 
-			# FIXME: don't count hidden tabs
-			$width = (int) (100 / count($tabs)) . '%';
-			foreach ($tabs as $tab_id => $tab) {
+            # FIXME: don't count hidden tabs
+            $width = (int) (100 / count($tabs)) . '%';
+            foreach ($tabs as $tab_id => $tab) {
 
-				$tabs[$tab_id]['active'] = $active = ($tab_id == $activetab) ? ' active' : '';
+                $tabs[$tab_id]['active'] = $active = ($tab_id == $activetab) ? ' active' : '';
 
-				$tabs[$tab_id]['width'] = $width;
+                $tabs[$tab_id]['width'] = $width;
 
-				if (!isset($tab['hide']) || $tab['hide'] !== true) {
+                if (!isset($tab['hide']) || $tab['hide'] !== true) {
 
-					$tabs[$tab_id]['tablink'] = htmlentities($this->getActionUrl($tab, $_REQUEST));
+                    $tabs[$tab_id]['tablink'] = htmlentities($this->getActionUrl($tab, $_REQUEST));
 
-					$tablink = '<a href="' . $tabs[$tab_id]['tablink'] . '">';
+                    $tablink = '<a href="' . $tabs[$tab_id]['tablink'] . '">';
 
-					if (isset($tab['icon']) && $icon = $misc->icon($tab['icon'])) {
-						$tabs[$tab_id]['iconurl'] = $icon;
-						$tablink .= "<span class=\"icon\"><img src=\"{$icon}\" alt=\"{$tab['title']}\" /></span>";
-					}
+                    if (isset($tab['icon']) && $icon = $misc->icon($tab['icon'])) {
+                        $tabs[$tab_id]['iconurl'] = $icon;
+                        $tablink .= "<span class=\"icon\"><img src=\"{$icon}\" alt=\"{$tab['title']}\" /></span>";
+                    }
 
-					$tablink .= "<span class=\"label\">{$tab['title']}</span></a>";
+                    $tablink .= "<span class=\"label\">{$tab['title']}</span></a>";
 
-					$tabs_html .= "<td style=\"width: {$width}\" class=\"tab{$active}\">";
+                    $tabs_html .= "<td style=\"width: {$width}\" class=\"tab{$active}\">";
 
-					if (isset($tab['help'])) {
-						$tabs_html .= $misc->printHelp($tablink, $tab['help'], false);
-					} else {
-						$tabs_html .= $tablink;
-					}
+                    if (isset($tab['help'])) {
+                        $tabs_html .= $misc->printHelp($tablink, $tab['help'], false);
+                    } else {
+                        $tabs_html .= $tablink;
+                    }
 
-					$tabs_html .= "</td>\n";
-				}
-			}
-			$tabs_html .= "</tr></table>\n";
-		}
+                    $tabs_html .= "</td>\n";
+                }
+            }
+            $tabs_html .= "</tr></table>\n";
+        }
 
-		if ($do_print) {
-			echo $tabs_html;
-		} else {
-			return $tabs_html;
-		}
+        if ($do_print) {
+            echo $tabs_html;
+        } else {
+            return $tabs_html;
+        }
 
-	}
+    }
 
-	/**
-	 * Get the URL for the last active tab of a particular tab bar.
-	 */
-	function getLastTabURL($section) {
-		$lang = $this->lang;
-		$misc = $this->misc;
+    /**
+     * Get the URL for the last active tab of a particular tab bar.
+     */
+    public function getLastTabURL($section)
+    {
+        $lang = $this->lang;
+        $misc = $this->misc;
 
-		$tabs = $misc->getNavTabs($section);
+        $tabs = $misc->getNavTabs($section);
 
-		if (isset($_SESSION['webdbLastTab'][$section]) && isset($tabs[$_SESSION['webdbLastTab'][$section]])) {
-			$tab = $tabs[$_SESSION['webdbLastTab'][$section]];
-		} else {
-			$tab = reset($tabs);
-		}
-		\PC::debug(['section' => $section, 'tabs' => $tabs, 'tab' => $tab], 'getLastTabURL');
-		return isset($tab['url']) ? $tab : null;
-	}
+        if (isset($_SESSION['webdbLastTab'][$section]) && isset($tabs[$_SESSION['webdbLastTab'][$section]])) {
+            $tab = $tabs[$_SESSION['webdbLastTab'][$section]];
+        } else {
+            $tab = reset($tabs);
+        }
+        \PC::debug(['section' => $section, 'tabs' => $tabs, 'tab' => $tab], 'getLastTabURL');
+        return isset($tab['url']) ? $tab : null;
+    }
 
-	/**
-	 * [printTopbar description]
-	 * @param  bool $do_print true to print, false to return html
-	 * @return string
-	 */
-	private function printTopbar($do_print = true) {
+    /**
+     * [printTopbar description]
+     * @param  bool $do_print true to print, false to return html
+     * @return string
+     */
+    private function printTopbar($do_print = true)
+    {
 
-		$lang = $this->lang;
-		$plugin_manager = $this->plugin_manager;
-		$misc = $this->misc;
-		$appName = $misc->appName;
-		$appVersion = $misc->appVersion;
-		$appLangFiles = $misc->appLangFiles;
+        $lang           = $this->lang;
+        $plugin_manager = $this->plugin_manager;
+        $misc           = $this->misc;
+        $appName        = $misc->appName;
+        $appVersion     = $misc->appVersion;
+        $appLangFiles   = $misc->appLangFiles;
 
-		$server_info = $misc->getServerInfo();
-		$server_id = $misc->getServerId();
-		$reqvars = $misc->getRequestVars('table');
+        $server_info = $misc->getServerInfo();
+        $server_id   = $misc->getServerId();
+        $reqvars     = $misc->getRequestVars('table');
 
-		$topbar_html = '<div class="topbar" data-controller="' . $this->controller_name . '"><table style="width: 100%"><tr><td>';
+        $topbar_html = '<div class="topbar" data-controller="' . $this->controller_name . '"><table style="width: 100%"><tr><td>';
 
-		if ($server_info && isset($server_info['platform']) && isset($server_info['username'])) {
-			/* top left informations when connected */
-			$topbar_html .= sprintf($lang['strtopbar'],
-				'<span class="platform">' . htmlspecialchars($server_info['platform']) . '</span>',
-				'<span class="host">' . htmlspecialchars((empty($server_info['host'])) ? 'localhost' : $server_info['host']) . '</span>',
-				'<span class="port">' . htmlspecialchars($server_info['port']) . '</span>',
-				'<span class="username">' . htmlspecialchars($server_info['username']) . '</span>');
+        if ($server_info && isset($server_info['platform']) && isset($server_info['username'])) {
+            /* top left informations when connected */
+            $topbar_html .= sprintf($lang['strtopbar'],
+                '<span class="platform">' . htmlspecialchars($server_info['platform']) . '</span>',
+                '<span class="host">' . htmlspecialchars((empty($server_info['host'])) ? 'localhost' : $server_info['host']) . '</span>',
+                '<span class="port">' . htmlspecialchars($server_info['port']) . '</span>',
+                '<span class="username">' . htmlspecialchars($server_info['username']) . '</span>');
 
-			$topbar_html .= "</td>";
+            $topbar_html .= "</td>";
 
-			/* top right informations when connected */
+            /* top right informations when connected */
 
-			$toplinks = [
-				'sql' => [
-					'attr' => [
-						'href' => [
-							'url' => '/src/views/sqledit.php',
-							'urlvars' => array_merge($reqvars, [
-								'action' => 'sql',
-							]),
-						],
-						'target' => "sqledit",
-						'id' => 'toplink_sql',
-					],
-					'content' => $lang['strsql'],
-				],
-				'history' => [
-					'attr' => [
-						'href' => [
-							'url' => '/src/views/history.php',
-							'urlvars' => array_merge($reqvars, [
-								'action' => 'pophistory',
-							]),
-						],
-						'id' => 'toplink_history',
-					],
-					'content' => $lang['strhistory'],
-				],
-				'find' => [
-					'attr' => [
-						'href' => [
-							'url' => '/src/views/sqledit.php',
-							'urlvars' => array_merge($reqvars, [
-								'action' => 'find',
-							]),
-						],
-						'target' => "sqledit",
-						'id' => 'toplink_find',
-					],
-					'content' => $lang['strfind'],
-				],
-				'logout' => [
-					'attr' => [
-						'href' => [
-							'url' => '/src/views/servers.php',
-							'urlvars' => [
-								'action' => 'logout',
-								'logoutServer' => "{$server_info['host']}:{$server_info['port']}:{$server_info['sslmode']}",
-							],
-						],
-						'id' => 'toplink_logout',
-					],
-					'content' => $lang['strlogout'],
-				],
-			];
+            $toplinks = [
+                'sql'     => [
+                    'attr'    => [
+                        'href'   => [
+                            'url'     => '/src/views/sqledit.php',
+                            'urlvars' => array_merge($reqvars, [
+                                'action' => 'sql',
+                            ]),
+                        ],
+                        'target' => "sqledit",
+                        'id'     => 'toplink_sql',
+                    ],
+                    'content' => $lang['strsql'],
+                ],
+                'history' => [
+                    'attr'    => [
+                        'href' => [
+                            'url'     => '/src/views/history.php',
+                            'urlvars' => array_merge($reqvars, [
+                                'action' => 'pophistory',
+                            ]),
+                        ],
+                        'id'   => 'toplink_history',
+                    ],
+                    'content' => $lang['strhistory'],
+                ],
+                'find'    => [
+                    'attr'    => [
+                        'href'   => [
+                            'url'     => '/src/views/sqledit.php',
+                            'urlvars' => array_merge($reqvars, [
+                                'action' => 'find',
+                            ]),
+                        ],
+                        'target' => "sqledit",
+                        'id'     => 'toplink_find',
+                    ],
+                    'content' => $lang['strfind'],
+                ],
+                'logout'  => [
+                    'attr'    => [
+                        'href' => [
+                            'url'     => '/src/views/servers.php',
+                            'urlvars' => [
+                                'action'       => 'logout',
+                                'logoutServer' => "{$server_info['host']}:{$server_info['port']}:{$server_info['sslmode']}",
+                            ],
+                        ],
+                        'id'   => 'toplink_logout',
+                    ],
+                    'content' => $lang['strlogout'],
+                ],
+            ];
 
-			// Toplink hook's place
-			$plugin_functions_parameters = [
-				'toplinks' => &$toplinks,
-			];
+            // Toplink hook's place
+            $plugin_functions_parameters = [
+                'toplinks' => &$toplinks,
+            ];
 
-			$plugin_manager->do_hook('toplinks', $plugin_functions_parameters);
+            $plugin_manager->do_hook('toplinks', $plugin_functions_parameters);
 
-			$topbar_html .= "<td style=\"text-align: right\">";
+            $topbar_html .= "<td style=\"text-align: right\">";
 
-			$topbar_html .= $this->printLinksList($toplinks, 'toplink', [], false);
+            $topbar_html .= $this->printLinksList($toplinks, 'toplink', [], false);
 
-			$topbar_html .= "</td>";
+            $topbar_html .= "</td>";
 
-			$sql_window_id = htmlentities('sqledit:' . $server_id);
-			$history_window_id = htmlentities('history:' . $server_id);
+            $sql_window_id     = htmlentities('sqledit:' . $server_id);
+            $history_window_id = htmlentities('history:' . $server_id);
 
-			$topbar_html .= "<script type=\"text/javascript\">
+            $topbar_html .= "<script type=\"text/javascript\">
 						$('#toplink_sql').click(function() {
 							window.open($(this).attr('href'),'{$sql_window_id}','toolbar=no,width=700,height=500,resizable=yes,scrollbars=yes').focus();
 							return false;
@@ -301,244 +307,252 @@ class HTMLNavbarController extends HTMLController {
 						});
 						";
 
-			if (isset($_SESSION['sharedUsername'])) {
-				$topbar_html .= sprintf("
+            if (isset($_SESSION['sharedUsername'])) {
+                $topbar_html .= sprintf("
 						$('#toplink_logout').click(function() {
 							return confirm('%s');
 						});", str_replace("'", "\'", $lang['strconfdropcred']));
-			}
+            }
 
-			$topbar_html .= "
+            $topbar_html .= "
 				</script>";
-		} else {
-			$topbar_html .= "<span class=\"appname\">{$appName}</span> <span class=\"version\">{$appVersion}</span>";
-		}
-		/*
-			echo "<td style=\"text-align: right; width: 1%\">";
+        } else {
+            $topbar_html .= "<span class=\"appname\">{$appName}</span> <span class=\"version\">{$appVersion}</span>";
+        }
+        /*
+        echo "<td style=\"text-align: right; width: 1%\">";
 
-			echo "<form method=\"get\"><select name=\"language\" onchange=\"this.form.submit()\">\n";
-			$language = isset($_SESSION['webdbLanguage']) ? $_SESSION['webdbLanguage'] : 'english';
-			foreach ($appLangFiles as $k => $v) {
-			echo "<option value=\"{$k}\"",
-			($k == $language) ? ' selected="selected"' : '',
-			">{$v}</option>\n";
-			}
-			echo "</select>\n";
-			echo "<noscript><input type=\"submit\" value=\"Set Language\"></noscript>\n";
-			foreach ($_GET as $key => $val) {
-			if ($key == 'language') continue;
-			echo "<input type=\"hidden\" name=\"$key\" value=\"", htmlspecialchars($val), "\" />\n";
-			}
-			echo "</form>\n";
+        echo "<form method=\"get\"><select name=\"language\" onchange=\"this.form.submit()\">\n";
+        $language = isset($_SESSION['webdbLanguage']) ? $_SESSION['webdbLanguage'] : 'english';
+        foreach ($appLangFiles as $k => $v) {
+        echo "<option value=\"{$k}\"",
+        ($k == $language) ? ' selected="selected"' : '',
+        ">{$v}</option>\n";
+        }
+        echo "</select>\n";
+        echo "<noscript><input type=\"submit\" value=\"Set Language\"></noscript>\n";
+        foreach ($_GET as $key => $val) {
+        if ($key == 'language') continue;
+        echo "<input type=\"hidden\" name=\"$key\" value=\"", htmlspecialchars($val), "\" />\n";
+        }
+        echo "</form>\n";
 
-			echo "</td>";
-		*/
-		$topbar_html .= "</tr></table></div>\n";
+        echo "</td>";
+         */
+        $topbar_html .= "</tr></table></div>\n";
 
-		if ($do_print) {
-			echo $topbar_html;
-		} else {
-			return $topbar_html;
-		}
-	}
+        if ($do_print) {
+            echo $topbar_html;
+        } else {
+            return $topbar_html;
+        }
+    }
 
-	/**
-	 * Create a bread crumb trail of the object hierarchy.
-	 * @param $object The type of object at the end of the trail.
-	 */
-	private function getTrail($subject = null) {
-		$lang = $this->lang;
-		$plugin_manager = $this->plugin_manager;
-		$misc = $this->misc;
-		$appName = $misc->appName;
+    private function getHREFSubject($subject)
+    {
+        $vars = $this->misc->getSubjectParams($subject);
+        return "{$vars['url']}?" . http_build_query($vars['params'], '', '&amp;');
+    }
 
-		$data = $misc->getDatabaseAccessor();
+    /**
+     * Create a bread crumb trail of the object hierarchy.
+     * @param $object The type of object at the end of the trail.
+     */
+    private function getTrail($subject = null)
+    {
+        $lang           = $this->lang;
+        $plugin_manager = $this->plugin_manager;
+        $misc           = $this->misc;
+        $appName        = $misc->appName;
 
-		$trail = [];
-		$vars = '';
-		$done = false;
+        $data = $misc->getDatabaseAccessor();
 
-		$trail['root'] = [
-			'text' => $appName,
-			'url' => '/redirect/root',
-			'icon' => 'Introduction',
-		];
+        $trail = [];
+        $vars  = '';
+        $done  = false;
 
-		if ($subject == 'root') {
-			$done = true;
-		}
+        $trail['root'] = [
+            'text' => $appName,
+            'url'  => '/redirect/root',
+            'icon' => 'Introduction',
+        ];
 
-		if (!$done) {
-			$server_info = $misc->getServerInfo();
-			$trail['server'] = [
-				'title' => $lang['strserver'],
-				'text' => $server_info['desc'],
-				'url' => $misc->getHREFSubject('server'),
-				'help' => 'pg.server',
-				'icon' => 'Server',
-			];
-		}
-		if ($subject == 'server') {
-			$done = true;
-		}
+        if ($subject == 'root') {
+            $done = true;
+        }
 
-		if (isset($_REQUEST['database']) && !$done) {
-			$trail['database'] = [
-				'title' => $lang['strdatabase'],
-				'text' => $_REQUEST['database'],
-				'url' => $misc->getHREFSubject('database'),
-				'help' => 'pg.database',
-				'icon' => 'Database',
-			];
-		} elseif (isset($_REQUEST['rolename']) && !$done) {
-			$trail['role'] = [
-				'title' => $lang['strrole'],
-				'text' => $_REQUEST['rolename'],
-				'url' => $misc->getHREFSubject('role'),
-				'help' => 'pg.role',
-				'icon' => 'Roles',
-			];
-		}
-		if ($subject == 'database' || $subject == 'role') {
-			$done = true;
-		}
+        if (!$done) {
+            $server_info     = $misc->getServerInfo();
+            $trail['server'] = [
+                'title' => $lang['strserver'],
+                'text'  => $server_info['desc'],
+                'url'   => $this->getHREFSubject('server'),
+                'help'  => 'pg.server',
+                'icon'  => 'Server',
+            ];
+        }
+        if ($subject == 'server') {
+            $done = true;
+        }
 
-		if (isset($_REQUEST['schema']) && !$done) {
-			$trail['schema'] = [
-				'title' => $lang['strschema'],
-				'text' => $_REQUEST['schema'],
-				'url' => $misc->getHREFSubject('schema'),
-				'help' => 'pg.schema',
-				'icon' => 'Schema',
-			];
-		}
-		if ($subject == 'schema') {
-			$done = true;
-		}
+        if (isset($_REQUEST['database']) && !$done) {
+            $trail['database'] = [
+                'title' => $lang['strdatabase'],
+                'text'  => $_REQUEST['database'],
+                'url'   => $this->getHREFSubject('database'),
+                'help'  => 'pg.database',
+                'icon'  => 'Database',
+            ];
+        } elseif (isset($_REQUEST['rolename']) && !$done) {
+            $trail['role'] = [
+                'title' => $lang['strrole'],
+                'text'  => $_REQUEST['rolename'],
+                'url'   => $this->getHREFSubject('role'),
+                'help'  => 'pg.role',
+                'icon'  => 'Roles',
+            ];
+        }
+        if ($subject == 'database' || $subject == 'role') {
+            $done = true;
+        }
 
-		if (isset($_REQUEST['table']) && !$done) {
-			$trail['table'] = [
-				'title' => $lang['strtable'],
-				'text' => $_REQUEST['table'],
-				'url' => $misc->getHREFSubject('table'),
-				'help' => 'pg.table',
-				'icon' => 'Table',
-			];
-		} elseif (isset($_REQUEST['view']) && !$done) {
-			$trail['view'] = [
-				'title' => $lang['strview'],
-				'text' => $_REQUEST['view'],
-				'url' => $misc->getHREFSubject('view'),
-				'help' => 'pg.view',
-				'icon' => 'View',
-			];
-		} elseif (isset($_REQUEST['matview']) && !$done) {
-			$trail['matview'] = [
-				'title' => 'M' . $lang['strview'],
-				'text' => $_REQUEST['matview'],
-				'url' => $misc->getHREFSubject('matview'),
-				'help' => 'pg.matview',
-				'icon' => 'MViews',
-			];
+        if (isset($_REQUEST['schema']) && !$done) {
+            $trail['schema'] = [
+                'title' => $lang['strschema'],
+                'text'  => $_REQUEST['schema'],
+                'url'   => $this->getHREFSubject('schema'),
+                'help'  => 'pg.schema',
+                'icon'  => 'Schema',
+            ];
+        }
+        if ($subject == 'schema') {
+            $done = true;
+        }
 
-		} elseif (isset($_REQUEST['ftscfg']) && !$done) {
-			$trail['ftscfg'] = [
-				'title' => $lang['strftsconfig'],
-				'text' => $_REQUEST['ftscfg'],
-				'url' => $misc->getHREFSubject('ftscfg'),
-				'help' => 'pg.ftscfg.example',
-				'icon' => 'Fts',
-			];
-		}
-		if ($subject == 'table' || $subject == 'view' || $subject == 'ftscfg') {
-			$done = true;
-		}
+        if (isset($_REQUEST['table']) && !$done) {
+            $trail['table'] = [
+                'title' => $lang['strtable'],
+                'text'  => $_REQUEST['table'],
+                'url'   => $this->getHREFSubject('table'),
+                'help'  => 'pg.table',
+                'icon'  => 'Table',
+            ];
+        } elseif (isset($_REQUEST['view']) && !$done) {
+            $trail['view'] = [
+                'title' => $lang['strview'],
+                'text'  => $_REQUEST['view'],
+                'url'   => $this->getHREFSubject('view'),
+                'help'  => 'pg.view',
+                'icon'  => 'View',
+            ];
+        } elseif (isset($_REQUEST['matview']) && !$done) {
+            $trail['matview'] = [
+                'title' => 'M' . $lang['strview'],
+                'text'  => $_REQUEST['matview'],
+                'url'   => $this->getHREFSubject('matview'),
+                'help'  => 'pg.matview',
+                'icon'  => 'MViews',
+            ];
 
-		if (!$done && !is_null($subject)) {
-			switch ($subject) {
-			case 'function':
-				$trail[$subject] = [
-					'title' => $lang['str' . $subject],
-					'text' => $_REQUEST[$subject],
-					'url' => $misc->getHREFSubject('function'),
-					'help' => 'pg.function',
-					'icon' => 'Function',
-				];
-				break;
-			case 'aggregate':
-				$trail[$subject] = [
-					'title' => $lang['straggregate'],
-					'text' => $_REQUEST['aggrname'],
-					'url' => $misc->getHREFSubject('aggregate'),
-					'help' => 'pg.aggregate',
-					'icon' => 'Aggregate',
-				];
-				break;
-			case 'column':
-				$trail['column'] = [
-					'title' => $lang['strcolumn'],
-					'text' => $_REQUEST['column'],
-					'icon' => 'Column',
-					'url' => $misc->getHREFSubject('column'),
-				];
-				break;
-			default:
-				if (isset($_REQUEST[$subject])) {
-					switch ($subject) {
-					case 'domain':$icon = 'Domain';
-						break;
-					case 'sequence':$icon = 'Sequence';
-						break;
-					case 'type':$icon = 'Type';
-						break;
-					case 'operator':$icon = 'Operator';
-						break;
-					default:$icon = null;
-						break;
-					}
-					$trail[$subject] = [
-						'title' => array_key_exists('str' . $subject, $lang) ? $lang['str' . $subject] : $subject,
-						'text' => $_REQUEST[$subject],
-						'help' => 'pg.' . $subject,
-						'icon' => $icon,
-					];
-				}
-			}
-		}
+        } elseif (isset($_REQUEST['ftscfg']) && !$done) {
+            $trail['ftscfg'] = [
+                'title' => $lang['strftsconfig'],
+                'text'  => $_REQUEST['ftscfg'],
+                'url'   => $this->getHREFSubject('ftscfg'),
+                'help'  => 'pg.ftscfg.example',
+                'icon'  => 'Fts',
+            ];
+        }
+        if ($subject == 'table' || $subject == 'view' || $subject == 'ftscfg') {
+            $done = true;
+        }
 
-		// Trail hook's place
-		$plugin_functions_parameters = [
-			'trail' => &$trail,
-			'section' => $subject,
-		];
+        if (!$done && !is_null($subject)) {
+            switch ($subject) {
+                case 'function':
+                    $trail[$subject] = [
+                        'title' => $lang['str' . $subject],
+                        'text'  => $_REQUEST[$subject],
+                        'url'   => $this->getHREFSubject('function'),
+                        'help'  => 'pg.function',
+                        'icon'  => 'Function',
+                    ];
+                    break;
+                case 'aggregate':
+                    $trail[$subject] = [
+                        'title' => $lang['straggregate'],
+                        'text'  => $_REQUEST['aggrname'],
+                        'url'   => $this->getHREFSubject('aggregate'),
+                        'help'  => 'pg.aggregate',
+                        'icon'  => 'Aggregate',
+                    ];
+                    break;
+                case 'column':
+                    $trail['column'] = [
+                        'title' => $lang['strcolumn'],
+                        'text'  => $_REQUEST['column'],
+                        'icon'  => 'Column',
+                        'url'   => $this->getHREFSubject('column'),
+                    ];
+                    break;
+                default:
+                    if (isset($_REQUEST[$subject])) {
+                        switch ($subject) {
+                            case 'domain':$icon = 'Domain';
+                                break;
+                            case 'sequence':$icon = 'Sequence';
+                                break;
+                            case 'type':$icon = 'Type';
+                                break;
+                            case 'operator':$icon = 'Operator';
+                                break;
+                            default:$icon = null;
+                                break;
+                        }
+                        $trail[$subject] = [
+                            'title' => array_key_exists('str' . $subject, $lang) ? $lang['str' . $subject] : $subject,
+                            'text'  => $_REQUEST[$subject],
+                            'help'  => 'pg.' . $subject,
+                            'icon'  => $icon,
+                        ];
+                    }
+            }
+        }
 
-		$plugin_manager->do_hook('trail', $plugin_functions_parameters);
+        // Trail hook's place
+        $plugin_functions_parameters = [
+            'trail'   => &$trail,
+            'section' => $subject,
+        ];
 
-		return $trail;
-	}
+        $plugin_manager->do_hook('trail', $plugin_functions_parameters);
 
-	/**
-	 * Display a list of links
-	 * @param $links An associative array of links to print. See printLink function for
-	 *               the links array format.
-	 * @param $class An optional class or list of classes seprated by a space
-	 *   WARNING: This field is NOT escaped! No user should be able to inject something here, use with care.
-	 * @param  boolean $do_print true to echo, false to return
-	 */
-	private function printLinksList($links, $class = '', $do_print = true) {
-		$misc = $this->misc;
-		$list_html = "<ul class=\"{$class}\">\n";
-		foreach ($links as $link) {
-			$list_html .= "\t<li>";
-			$list_html .= $this->printLink($link, false);
-			$list_html .= "</li>\n";
-		}
-		$list_html .= "</ul>\n";
-		if ($do_print) {
-			echo $list_html;
-		} else {
-			return $list_html;
-		}
-	}
+        return $trail;
+    }
+
+    /**
+     * Display a list of links
+     * @param $links An associative array of links to print. See printLink function for
+     *               the links array format.
+     * @param $class An optional class or list of classes seprated by a space
+     *   WARNING: This field is NOT escaped! No user should be able to inject something here, use with care.
+     * @param  boolean $do_print true to echo, false to return
+     */
+    private function printLinksList($links, $class = '', $do_print = true)
+    {
+        $misc      = $this->misc;
+        $list_html = "<ul class=\"{$class}\">\n";
+        foreach ($links as $link) {
+            $list_html .= "\t<li>";
+            $list_html .= $this->printLink($link, false);
+            $list_html .= "</li>\n";
+        }
+        $list_html .= "</ul>\n";
+        if ($do_print) {
+            echo $list_html;
+        } else {
+            return $list_html;
+        }
+    }
 
 }

--- a/templates/sqledit_footer.twig
+++ b/templates/sqledit_footer.twig
@@ -1,26 +1,31 @@
 <script type="text/javascript">
-jQuery(document).ready(function() {
-    document.forms[0].query.focus();
-    CodeMirror.commands.sendQuery = function() {
+jQuery(document).ready(function () {
+
+    jQuery('#query').focus();
+    CodeMirror.commands.sendQuery = function () {
         console.log('SEND QUERY');
         jQuery('#sqlform').submit();
     };
-    window.editor = CodeMirror.fromTextArea($('#query')[0], {
-        mode: 'text/x-sql',
-        indentWithTabs: true,
-        smartIndent: true,
-        lineNumbers: true,
-        matchBrackets: true,
-        autofocus: true,
-        extraKeys: {
-            "Ctrl-Space": "autocomplete",
-            "Ctrl-Enter": "sendQuery"
-        },
-        foldGutter: true,
-        gutters: ["CodeMirror-linenumbers", "CodeMirror-foldgutter"]
-    });
+    if (jQuery('#query').length) {
+        window.editor = CodeMirror.fromTextArea($('#query')[0], {
+            mode: 'text/x-sql',
+            indentWithTabs: true,
+            smartIndent: true,
+            lineNumbers: true,
+            matchBrackets: true,
+            autofocus: true,
+            extraKeys: {
+                "Ctrl-Space": "autocomplete",
+                "Ctrl-Enter": "sendQuery"
+            },
+            foldGutter: true,
+            gutters: ["CodeMirror-linenumbers", "CodeMirror-foldgutter"]
+        });
+    }
+
     jQuery('table.tabs').prependTo('body');
     jQuery('table.printconnection').prependTo('.sqlform');
+
     if (window.parent.frames.length > 1) {
         $('#csstheme', window.parent.frames[0].document).attr('href', '/src/themes/default/global.css');
     }
@@ -29,13 +34,7 @@ jQuery(document).ready(function() {
         .focus()
         .css('height', $('#query').attr('rows') * 30);
     if (location.pathname.indexOf('sqledit.php') !== -1) {
-        /*jQuery('.sqledit_header,.sqledit_footer,.printconnection').css({
-            'padding': '1%',
-            width: '98%'
-        });
-        jQuery('.printconnection label').css({
-            'font-size': '0.9em'
-        });*/
+
         var windowsize = {
             height: jQuery(window).innerHeight(),
             width: jQuery(window).innerWidth(),
@@ -43,7 +42,7 @@ jQuery(document).ready(function() {
         };
         console.log('window size', windowsize);
         var height_difference = windowsize.height - jQuery('.CodeMirror').innerHeight();
-        jQuery(window).on('resize', function() {
+        jQuery(window).on('resize', function () {
             var windowsize = {
                 height: jQuery(window).innerHeight(),
                 width: jQuery(window).innerWidth(),
@@ -58,38 +57,6 @@ jQuery(document).ready(function() {
     }
 });
 </script>
-<!--
-     jQuery('.CodeMirror')
-        .focus()
-        .css('height', $('#query').attr('rows') * 30);
-    if (location.pathname.indexOf('sqledit.php') !== -1) {
-        /*jQuery('.sqledit_header,.sqledit_footer,.printconnection').css({
-            'padding': '1%',
-            width: '98%'
-        });
-        jQuery('.printconnection label').css({
-            'font-size': '0.9em'
-        });*/
-        var windowsize = {
-            height: jQuery(window).innerHeight(),
-            width: jQuery(window).innerWidth(),
-            height_difference: height_difference
-        };
-        console.log('window size', windowsize);
-        var height_difference = windowsize.height - jQuery('.CodeMirror').innerHeight();
-        jQuery(window).on('resize', function() {
-            var windowsize = {
-                height: jQuery(window).innerHeight(),
-                width: jQuery(window).innerWidth(),
-                height_difference: height_difference
-            };
-            //console.log('window size', windowsize);
-            jQuery('.CodeMirror').css('height', (windowsize.height - height_difference));
-        });
-    } else {
-        jQuery('.CodeMirror')
-            .resizable();
-    }-->
 
 </body>
 


### PR DESCRIPTION
As suggested in https://github.com/phppgadmin/phppgadmin/pull/42

- Uses htmlspecialchars to wrap query content inside textares
- Uses htmlspecialchars to sanitize error messages on ADODB_Exception
- Avoids instancing CodeMirror is there is no element with id "query"
- $debugmode must be set on the configfile

htmlspecialchars on exception