### PR TITLE
Feature/browser in body

### DIFF
--- a/codacy.yml
+++ b/codacy.yml
@@ -26,7 +26,7 @@ engines:
      - temp/**/*
      - '.test/**/*'
  pmd:
-   enabled: true
+   enabled: false
  sqlint:
    enabled: true
  stylelink:

--- a/codacy.yml
+++ b/codacy.yml
@@ -1,0 +1,63 @@
+---
+engines:
+ csslint:
+   enabled: false
+ eslint:
+   enabled: true
+ jshint:
+   enabled: false
+ phpmd:
+   enabled: true
+   exclude_paths:
+     - temp/**/*
+     - ".tests/**/*"
+ jacksonlinter:
+   enabled: false
+ node_security:
+   enabled: false
+ php_code_sniffer:
+   enabled: true
+   exclude_paths:
+     - temp/**/*
+     - '.test/**/*'   
+ php_mess_detector:
+   enabled: true
+   exclude_paths:
+     - temp/**/*
+     - '.test/**/*'
+ pmd:
+   enabled: true
+ sqlint:
+   enabled: true
+ stylelink:
+   enabled: false   
+ duplication:
+   enabled: true
+   exclude_paths:
+     - temp/**/*
+     - ".tests/**/*"
+ metrics:
+   enabled: true
+   exclude_paths:
+    - temp/**/*
+    - ".tests/**/*"
+ coverage:
+   enabled: true
+   exclude_paths:
+     - temp/**/*
+     - ".tests/**/*"
+languages:
+  css:
+    extensions:
+      - "*.css"
+      - "*.less"
+  php:
+    extensions:
+      - "*.php"
+
+exclude_paths:
+  - vendor/  
+  - .temp/**
+  - .tests/**/*
+  - "*.min.js"
+  - "*.min.css"

--- a/templates/browserbody.twig
+++ b/templates/browserbody.twig
@@ -1,0 +1,8 @@
+<body data-controller="{{controller}}" data-template="{{bodytemplate}}" class="flexbox_body">
+    <div class="flexbox_wrapper">
+        <div id="browser_container">
+            <iframe src="{{subfolder}}/src/views/browser.php" name="browser" id="browser" class="browser_container" frameborder="0" />
+            <p>Your browser does not support iframes.</p>
+            </iframe>
+        </div>
+        <div class="{{bodyClass}}">

--- a/templates/emptybody.twig
+++ b/templates/emptybody.twig
@@ -1,0 +1,1 @@
+<body data-controller="{{controller}}" data-template="{{bodytemplate}}" class="{{bodyclass}}">


### PR DESCRIPTION
Instead of having the default templates use two iframes, the browser code should be in every default template, and call other views/paths using the iframe as target.