### PR TITLE
Better theme management

### DIFF
--- a/index.php
+++ b/index.php
@@ -168,6 +168,11 @@ $app->get('/[{subject}]', function ($request, $response, $args) use ($msg, $cont
         $subject = 'intro';
     }
 
+    /*\Kint::dump($this->view->offsetGet('subfolder'));
+    \Kint::dump($this->view->offsetGet('theme'));
+    \Kint::dump($this->conf);
+    die();*/
+
     $url = '/src/views/' . $subject . '.php' . ($query_string ? '?' . $query_string : '');
 
     \PC::debug(['subject' => $subject, 'url' => $url, 'query_string' => $query_string], 'subject');

--- a/src/classes/HelperTrait.php
+++ b/src/classes/HelperTrait.php
@@ -59,6 +59,16 @@ trait HelperTrait
     }
 
     /**
+     * Returns a string with html <br> variant replaced with a new line
+     * @param  string $msg [description]
+     * @return string      [description]
+     */
+    public static function br2ln(string $msg)
+    {
+        return str_replace(['<br>', '<br/>', '<br />'], "\n", $msg);
+    }
+
+    /**
      * Prints the page header.  If member variable $this->_no_output is
      * set then no header is drawn.
      * @param $title The title of the page

--- a/src/classes/Misc.php
+++ b/src/classes/Misc.php
@@ -42,9 +42,9 @@ class Misc
 
         $this->container = $container;
 
-        $this->lang           = $container->get('lang');
-        $this->conf           = $container->get('conf');
-        $this->view           = $container->get('view');
+        $this->lang = $container->get('lang');
+        $this->conf = $container->get('conf');
+        //$this->view           = $container->get('view');
         $this->plugin_manager = $container->get('plugin_manager');
         $this->appLangFiles   = $container->get('appLangFiles');
 
@@ -78,6 +78,28 @@ class Misc
         } else if (isset($_SESSION['webdbLogin']) && count($_SESSION['webdbLogin']) > 0) {
             $this->server_id = array_keys($_SESSION['webdbLogin'])[0];
         }
+    }
+
+    public function setView($view)
+    {
+        $this->view = $view;
+    }
+
+    public function setConf($conf)
+    {
+        $this->conf = $conf;
+    }
+
+    public function getConf()
+    {
+        return $this->conf;
+    }
+
+    public function setTheme($theme)
+    {
+
+        $this->conf['theme'] = $theme;
+        return $this;
     }
 
     /**
@@ -385,20 +407,6 @@ class Misc
         $info = $this->getServerInfo();
 
         return !empty($info[$all ? 'pg_dumpall_path' : 'pg_dump_path']);
-    }
-
-    public function setThemeConf($theme_conf)
-    {
-
-        $this->conf['theme'] = $theme_conf;
-        //\PC::debug(['theme_conf' => $theme_conf, 'this->theme' => $this->conf['theme']], 'setThemeConf');
-        $this->view->offsetSet('theme', $this->conf['theme']);
-        return $this;
-    }
-
-    public function getConf()
-    {
-        return $this->conf;
     }
 
     /**

--- a/src/classes/Misc.php
+++ b/src/classes/Misc.php
@@ -146,9 +146,9 @@ class Misc
             'line'     => $backtrace[0]['line'],
         ];
 
-        $errmsg = htmlspecialchars($errmsg);
-        $p1     = htmlspecialchars($p1);
-        $p2     = htmlspecialchars($p2);
+        $errmsg = htmlspecialchars(\PHPPgAdmin\HelperTrait::br2ln($errmsg));
+        $p1     = htmlspecialchars(\PHPPgAdmin\HelperTrait::br2ln($p1));
+        $p2     = htmlspecialchars(\PHPPgAdmin\HelperTrait::br2ln($p2));
         switch ($fn) {
             case 'EXECUTE':
                 $sql         = $p1;
@@ -156,9 +156,9 @@ class Misc
 
                 /*$s = "<p><b>{$lang['strsqlerror']}</b><br />" . $misc->printVal($errmsg, 'errormsg') . "</p> <p><b>{$lang['strinstatement']}</b><br />" . $misc->printVal($sql). "</p>    ";*/
 
-                $s = '<p><b>strsqlerror</b><br />' . $errmsg . '</p> <p><b>SQL:</b><br />' . $sql . '</p>	';
+                $s = '<p><b>strsqlerror</b><br />' . nl2br($errmsg) . '</p> <p><b>SQL:</b><br />' . nl2br($sql) . '</p>	';
 
-                echo '<table class="error" cellpadding="5"><tr><td>' . $s . '</td></tr></table><br />' . "\n";
+                echo '<table class="error" cellpadding="5"><tr><td>' . nl2br($s) . '</td></tr></table><br />' . "\n";
 
                 break;
 
@@ -713,7 +713,7 @@ class Misc
             case 'cid':
             case 'tid':
                 $align = 'right';
-                $out   = nl2br(htmlspecialchars($str));
+                $out   = nl2br(htmlspecialchars(\PHPPgAdmin\HelperTrait::br2ln($str)));
                 break;
             case 'yesno':
                 if (!isset($params['true'])) {
@@ -763,7 +763,8 @@ class Misc
                 $out = $str;
                 break;
             case 'nbsp':
-                $out = nl2br(str_replace(' ', '&nbsp;', htmlspecialchars($str)));
+                $out = nl2br(str_replace(' ', '&nbsp;', \PHPPgAdmin\HelperTrait::br2ln($str)));
+
                 break;
             case 'verbatim':
                 $out = $str;
@@ -812,7 +813,7 @@ class Misc
                     $class = 'data';
                     $out   = htmlspecialchars($str);
                 } else {
-                    $out = nl2br(htmlspecialchars($str));
+                    $out = nl2br(htmlspecialchars(\PHPPgAdmin\HelperTrait::br2ln($str)));
                 }
         }
 
@@ -888,8 +889,7 @@ class Misc
     public function printMsg($msg, $do_print = true)
     {
         $html = '';
-        $msg  = str_replace(['<br>', '<br/>', '<br />'], "\n", $msg);
-        $msg  = htmlspecialchars($msg);
+        $msg  = htmlspecialchars(\PHPPgAdmin\HelperTrait::br2ln($msg));
         if ($msg != '') {
 
             $html .= '<p class="message">' . nl2br($msg) . '</p>' . "\n";

--- a/src/classes/Misc.php
+++ b/src/classes/Misc.php
@@ -80,26 +80,40 @@ class Misc
         }
     }
 
-    public function setView($view)
+    /**
+     * Sets the view instance property of this class
+     * @param \Slim\Views\Twig $view [description]
+     */
+    public function setView(\Slim\Views\Twig $view)
     {
         $this->view = $view;
     }
 
-    public function setConf($conf)
+    /**
+     * Adds or modifies a key in the $conf instance property of this class
+     * @param string $key   [description]
+     * @param mixed $value [description]
+     * @return $this
+     */
+    public function setConf(string $key, $value)
     {
-        $this->conf = $conf;
-    }
-
-    public function getConf()
-    {
-        return $this->conf;
-    }
-
-    public function setTheme($theme)
-    {
-
-        $this->conf['theme'] = $theme;
+        $this->conf[$key] = $value;
         return $this;
+    }
+
+    /**
+     * gets the value of a config property, or the array of all config properties
+     * @param  mixed $key value of the key to be retrieved. If null, the full array is returnes
+     * @return mixed the whole $conf array, the value of $conf[key] or null if said key does not exist
+     */
+    public function getConf($key = null)
+    {
+        if ($key === null) {
+            return $this->conf;
+        } else if (array_key_exists($key, $this->conf)) {
+            return $this->conf[$key];
+        }
+        return null;
     }
 
     /**

--- a/src/controllers/IntroController.php
+++ b/src/controllers/IntroController.php
@@ -48,7 +48,8 @@ class IntroController extends BaseController
     public function doDefault()
     {
 
-        $conf = $this->conf;
+        //$conf = $this->conf;
+        $conf = $this->misc->getConf();
         $misc = $this->misc;
         $lang = $this->lang;
 

--- a/src/controllers/IntroController.php
+++ b/src/controllers/IntroController.php
@@ -13,7 +13,6 @@ class IntroController extends BaseController
     public function __construct(\Slim\Container $container)
     {
         $this->misc = $container->get('misc');
-
         $this->misc->setNoDBConnection(true);
         parent::__construct($container);
     }
@@ -48,8 +47,7 @@ class IntroController extends BaseController
     public function doDefault()
     {
 
-        //$conf = $this->conf;
-        $conf = $this->misc->getConf();
+        $conf = $this->conf;
         $misc = $this->misc;
         $lang = $this->lang;
 

--- a/src/lib.inc.php
+++ b/src/lib.inc.php
@@ -264,6 +264,8 @@ $container['view'] = function ($c) {
 
     $view->offsetSet('subfolder', SUBFOLDER);
     $view->offsetSet('theme', $c->misc->getConf('theme'));
+    $view->offsetSet('Favicon', $c->misc->icon('Favicon'));
+    $view->offsetSet('Introduction', $c->misc->icon('Introduction'));
 
     $misc->setView($view);
 

--- a/src/lib.inc.php
+++ b/src/lib.inc.php
@@ -235,8 +235,7 @@ $container['misc'] = function ($c) {
 
     }
 
-    $misc->setConf($conf);
-    $misc->setTheme($conf['theme']);
+    $misc->setConf('theme', $conf['theme']);
 
     $misc->setHREF();
     $misc->setForm();
@@ -264,11 +263,11 @@ $container['view'] = function ($c) {
     $view->addExtension(new Slim\Views\TwigExtension($c['router'], $basePath));
 
     $view->offsetSet('subfolder', SUBFOLDER);
-    $view->offsetSet('theme', $c->misc->getConf()['theme']);
+    $view->offsetSet('theme', $c->misc->getConf('theme'));
 
     $misc->setView($view);
 
-    \PC::debug($c->conf, 'conf');
+    //\PC::debug($c->conf, 'conf');
     //\PC::debug($c->view->offsetGet('subfolder'), 'subfolder');
     //\PC::debug($c->view->offsetGet('theme'), 'theme');
 

--- a/src/lib.inc.php
+++ b/src/lib.inc.php
@@ -6,7 +6,7 @@
  * $Id: lib.inc.php,v 1.123 2008/04/06 01:10:35 xzilla Exp $
  */
 
-defined('BASE_PATH') or define('BASE_PATH', dirname(__DIR__));
+defined('BASE_PATH') or DEFINE('BASE_PATH', dirname(__DIR__));
 
 DEFINE('THEME_PATH', BASE_PATH . '/src/themes');
 // Enforce PHP environment
@@ -22,42 +22,42 @@ if (file_exists(BASE_PATH . '/config.inc.php')) {
     die('Configuration error: Copy config.inc.php-dist to config.inc.php and edit appropriately.');
 
 }
-$debugmode = (!isset($conf['debugmode'])) ? false : $conf['debugmode'];
+$debugmode = (!isset($conf['debugmode'])) ? false : boolval($conf['debugmode']);
+DEFINE('DEBUGMODE', $debugmode);
 
-if ($debugmode) {
-    ini_set('display_errors', 1);
-    ini_set('display_startup_errors', 1);
-    error_reporting(E_ALL);
-}
+require_once BASE_PATH . '/vendor/autoload.php';
 
 if (!defined('ADODB_ERROR_HANDLER_TYPE')) {
     define('ADODB_ERROR_HANDLER_TYPE', E_USER_ERROR);
 }
+
 if (!defined('ADODB_ERROR_HANDLER')) {
-    //define('ADODB_ERROR_HANDLER', '\PHPPgAdmin\Misc::Error_Handler');
     define('ADODB_ERROR_HANDLER', '\PHPPgAdmin\Misc::adodb_throw');
 }
-
-require_once BASE_PATH . '/vendor/autoload.php';
 
 // Start session (if not auto-started)
 if (!ini_get('session.auto_start')) {
     session_name('PPA_ID');
     session_start();
 }
-\Kint::$enabled_mode = $debugmode;
 
-$composerinfo = json_decode(file_get_contents(BASE_PATH . '/composer.json'));
-$appVersion   = $composerinfo->version;
-
-$handler = PhpConsole\Handler::getInstance();
-if (!$debugmode) {
+$handler             = PhpConsole\Handler::getInstance();
+\Kint::$enabled_mode = DEBUGMODE;
+if (DEBUGMODE) {
+    ini_set('display_errors', 1);
+    ini_set('display_startup_errors', 1);
+    error_reporting(E_ALL);
+} else {
     $handler->setHandleErrors(false); // disable errors handling
     $handler->setHandleExceptions(false); // disable exceptions handling
     $handler->setCallOldHandlers(true); // disable passing errors & exceptions to prviously defined handlers
 }
+
 $handler->start(); // initialize handlers*/
-PhpConsole\Helper::register(); // it will register global PC class
+\PhpConsole\Helper::register(); // it will register global PC class
+
+$composerinfo = json_decode(file_get_contents(BASE_PATH . '/composer.json'));
+$appVersion   = $composerinfo->version;
 
 $config = [
     'msg'       => '',
@@ -69,7 +69,7 @@ $config = [
     ],
     'settings'  => [
         'base_path'              => BASE_PATH,
-        'debug'                  => $debugmode,
+        'debug'                  => DEBUGMODE,
 
         // Configuration file version.  If this is greater than that in config.inc.php, then
         // the app will refuse to run.  This and $conf['version'] should be incremented whenever
@@ -82,7 +82,7 @@ $config = [
 
         // PostgreSQL and PHP minimum version
         'postgresqlMinVer'       => '9.3',
-        'phpMinVer'              => '5.5',
+        'phpMinVer'              => '5.6',
         'displayErrorDetails'    => true,
         'addContentLengthHeader' => false,
     ],
@@ -110,6 +110,7 @@ $container['add_error'] = function ($c) {
 
 $container['conf'] = function ($c) use ($conf) {
 
+    //\Kint::dump($conf);
     // Plugins are removed
     $conf['plugins'] = [];
 
@@ -137,33 +138,6 @@ $container['serializer'] = function ($c) {
         ->setDebug($c->get('settings')['debug'])
         ->build();
     return $serializer;
-};
-
-// Register Twig View helper
-$container['view'] = function ($c) {
-
-    //\Kint::dump($c->get('settings'));
-    //die();
-
-    $view = new \Slim\Views\Twig(BASE_PATH . '/templates', [
-        'cache'       => BASE_PATH . '/temp/twigcache',
-        'auto_reload' => $c->get('settings')['debug'],
-        'debug'       => $c->get('settings')['debug'],
-    ]);
-    $environment               = $c->get('environment');
-    $base_script_trailing_shit = substr($environment['SCRIPT_NAME'], 1);
-    $request_basepath          = $c['request']->getUri()->getBasePath();
-    // Instantiate and add Slim specific extension
-    $basePath = rtrim(str_ireplace($base_script_trailing_shit, '', $request_basepath), '/');
-
-    $view->addExtension(new Slim\Views\TwigExtension($c['router'], $basePath));
-
-    $view->offsetSet('subfolder', SUBFOLDER);
-
-    //\Kint::dump(SUBFOLDER, $request_basepath, $base_script_trailing_shit, $basePath);
-    //die();
-
-    return $view;
 };
 
 // Create Misc class references
@@ -258,15 +232,47 @@ $container['misc'] = function ($c) {
         setcookie('ppaTheme', $_theme, time() + 31536000, '/');
         $_SESSION['ppaTheme'] = $_theme;
         $conf['theme']        = $_theme;
+
     }
 
-    $misc->setThemeConf($conf['theme']);
+    $misc->setConf($conf);
+    $misc->setTheme($conf['theme']);
 
-    // This has to be deferred until after stripVar above
     $misc->setHREF();
     $misc->setForm();
 
     return $misc;
+};
+
+// Register Twig View helper
+$container['view'] = function ($c) {
+
+    $conf = $c->get('conf');
+    $misc = $c->misc;
+
+    $view = new \Slim\Views\Twig(BASE_PATH . '/templates', [
+        'cache'       => BASE_PATH . '/temp/twigcache',
+        'auto_reload' => $c->get('settings')['debug'],
+        'debug'       => $c->get('settings')['debug'],
+    ]);
+    $environment               = $c->get('environment');
+    $base_script_trailing_shit = substr($environment['SCRIPT_NAME'], 1);
+    $request_basepath          = $c['request']->getUri()->getBasePath();
+    // Instantiate and add Slim specific extension
+    $basePath = rtrim(str_ireplace($base_script_trailing_shit, '', $request_basepath), '/');
+
+    $view->addExtension(new Slim\Views\TwigExtension($c['router'], $basePath));
+
+    $view->offsetSet('subfolder', SUBFOLDER);
+    $view->offsetSet('theme', $c->misc->getConf()['theme']);
+
+    $misc->setView($view);
+
+    \PC::debug($c->conf, 'conf');
+    //\PC::debug($c->view->offsetGet('subfolder'), 'subfolder');
+    //\PC::debug($c->view->offsetGet('theme'), 'theme');
+
+    return $view;
 };
 
 $container['haltHandler'] = function ($c) {

--- a/src/xhtml/HTMLController.php
+++ b/src/xhtml/HTMLController.php
@@ -30,13 +30,13 @@ class HTMLController
     {
         $this->container      = $container;
         $this->lang           = $container->get('lang');
-        $this->conf           = $container->get('conf');
         $this->view           = $container->get('view');
         $this->plugin_manager = $container->get('plugin_manager');
         $this->appName        = $container->get('settings')['appName'];
         $this->appVersion     = $container->get('settings')['appVersion'];
         $this->appLangFiles   = $container->get('appLangFiles');
         $this->misc           = $container->get('misc');
+        $this->conf           = $this->misc->getConf();
         $this->appThemes      = $container->get('appThemes');
         $this->action         = $container->get('action');
         if ($controller_name !== null) {

--- a/src/xhtml/TreeController.php
+++ b/src/xhtml/TreeController.php
@@ -28,15 +28,16 @@ class TreeController extends HTMLController
     /* Constructor */
     public function __construct(\Slim\Container $container, $controller_name = null)
     {
-        $this->container      = $container;
-        $this->lang           = $container->get('lang');
-        $this->conf           = $container->get('conf');
+        $this->container = $container;
+        $this->lang      = $container->get('lang');
+        //$this->conf           = $container->get('conf');
         $this->view           = $container->get('view');
         $this->plugin_manager = $container->get('plugin_manager');
         $this->appName        = $container->get('settings')['appName'];
         $this->appVersion     = $container->get('settings')['appVersion'];
         $this->appLangFiles   = $container->get('appLangFiles');
         $this->misc           = $container->get('misc');
+        $this->conf           = $this->misc->getConf();
         $this->appThemes      = $container->get('appThemes');
         $this->action         = $container->get('action');
         if ($controller_name !== null) {

--- a/src/xhtml/TreeController.php
+++ b/src/xhtml/TreeController.php
@@ -124,12 +124,12 @@ class TreeController extends HTMLController
                 echo Decorator::value_xml_attr('action', $attrs['action'], $rec);
                 echo Decorator::value_xml_attr('src', $attrs['branch'], $rec);
 
-                $icon = $this->icon(Decorator::get_sanitized_value($attrs['icon'], $rec));
+                $icon = $this->misc->icon(Decorator::get_sanitized_value($attrs['icon'], $rec));
                 echo Decorator::value_xml_attr('icon', $icon, $rec);
                 echo Decorator::value_xml_attr('iconaction', $attrs['iconAction'], $rec);
 
                 if (!empty($attrs['openicon'])) {
-                    $icon = $this->icon(Decorator::get_sanitized_value($attrs['openIcon'], $rec));
+                    $icon = $this->misc->icon(Decorator::get_sanitized_value($attrs['openIcon'], $rec));
                 }
                 echo Decorator::value_xml_attr('openicon', $icon, $rec);
 
@@ -139,7 +139,7 @@ class TreeController extends HTMLController
             }
         } else {
             $msg = isset($attrs['nodata']) ? $attrs['nodata'] : $lang['strnoobjects'];
-            echo "<tree text=\"{$msg}\" onaction=\"tree.getSelected().getParent().reload()\" icon=\"", $this->icon('ObjectNotFound'), '" />' . "\n";
+            echo "<tree text=\"{$msg}\" onaction=\"tree.getSelected().getParent().reload()\" icon=\"", $this->misc->icon('ObjectNotFound'), '" />' . "\n";
         }
 
         echo "</tree>\n";
@@ -156,39 +156,4 @@ class TreeController extends HTMLController
         return new \PHPPgAdmin\ArrayRecordSet($tabs);
     }
 
-    public function icon($icon)
-    {
-        if (is_string($icon)) {
-            $path = "/images/themes/{$this->conf['theme']}/{$icon}";
-            if (file_exists(BASE_PATH . $path . '.png')) {
-                return SUBFOLDER . $path . '.png';
-            }
-
-            if (file_exists(BASE_PATH . $path . '.gif')) {
-                return SUBFOLDER . $path . '.gif';
-            }
-
-            $path = "/images/themes/default/{$icon}";
-            if (file_exists(BASE_PATH . $path . '.png')) {
-                return SUBFOLDER . $path . '.png';
-            }
-
-            if (file_exists(BASE_PATH . $path . '.gif')) {
-                return SUBFOLDER . $path . '.gif';
-            }
-
-        } else {
-            // Icon from plugins
-            $path = "/plugins/{$icon[0]}/images/{$icon[1]}";
-            if (file_exists(BASE_PATH . $path . '.png')) {
-                return SUBFOLDER . $path . '.png';
-            }
-
-            if (file_exists(BASE_PATH . $path . '.gif')) {
-                return SUBFOLDER . $path . '.gif';
-            }
-
-        }
-        return '';
-    }
 }

--- a/templates/datatables_header.twig
+++ b/templates/datatables_header.twig
@@ -6,12 +6,10 @@
 
         <link rel="stylesheet/less" href="{{subfolder}}/src/themes/global.less" type="text/css" id="cssmain" />
         <link rel="stylesheet" href="{{subfolder}}/src/themes/{{theme}}/global.css" type="text/css" id="csstheme" />
-
         <link rel="stylesheet" href="{{subfolder}}/src/themes/datatables.min.css" type="text/css" />
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.0/jquery-ui.min.css" type="text/css" />
-
-        <link rel="shortcut icon" href="{{subfolder}}/images/themes/{{theme}}/Favicon.ico" type="image/vnd.microsoft.icon" />
-        <link rel="icon" type="image/png" href="{{subfolder}}/images/themes/{{theme}}/Introduction.png" />
+        <link rel="shortcut icon" href="{{Favicon}}" type="image/vnd.microsoft.icon" />
+        <link rel="icon" href="{{Introduction}}" type="image/png" />
 
         <script src="{{subfolder}}/js/less.min.js" type="text/javascript"></script>
         <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.0/jquery.min.js"></script>
@@ -19,11 +17,3 @@
         <script src="{{subfolder}}/js/datatables.min.js"></script>
 
         <title data-headertemplate="{{headertemplate}}">{{appName}}</title>
-
-        <script type="text/javascript">
-        $(document).ready(function () {
-            if (window.parent.frames.length > 1) {
-                $('#csstheme', window.parent.frames[0].document).attr('href', '{{subfolder}}/src/themes/{{theme}}/global.css');
-            }
-        });
-        </script>

--- a/templates/header.twig
+++ b/templates/header.twig
@@ -6,11 +6,9 @@
 
         <link rel="stylesheet/less" href="{{subfolder}}/src/themes/global.less" type="text/css" id="cssmain" />
         <link rel="stylesheet" href="{{subfolder}}/src/themes/{{theme}}/global.css" type="text/css" id="csstheme" />
-
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.0/jquery-ui.min.css" type="text/css" />
-
-        <link rel="shortcut icon" href="{{subfolder}}/images/themes/{{theme}}/Favicon.ico" type="image/vnd.microsoft.icon" />
-        <link rel="icon" type="image/png" href="{{subfolder}}/images/themes/{{theme}}/Introduction.png" />
+        <link rel="shortcut icon" href="{{Favicon}}" type="image/vnd.microsoft.icon" />
+        <link rel="icon" href="{{Introduction}}" type="image/png" />
 
         <script src="{{subfolder}}/js/less.min.js" type="text/javascript"></script>
         <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.0/jquery.min.js"></script>

--- a/templates/iframe_header.twig
+++ b/templates/iframe_header.twig
@@ -6,11 +6,9 @@
 
         <link rel="stylesheet/less" href="{{subfolder}}/src/themes/global.less" type="text/css" id="cssmain" />
         <link rel="stylesheet" href="{{subfolder}}/src/themes/{{theme}}/global.css" type="text/css" id="csstheme" />
-
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.0/jquery-ui.min.css" type="text/css" />
-
-        <link rel="shortcut icon" href="{{subfolder}}/images/themes/{{theme}}/Favicon.ico" type="image/vnd.microsoft.icon" />
-        <link rel="icon" type="image/png" href="{{subfolder}}/images/themes/{{theme}}/Introduction.png" />
+        <link rel="shortcut icon" href="{{Favicon}}" type="image/vnd.microsoft.icon" />
+        <link rel="icon" href="{{Introduction}}" type="image/png" />
 
         <script src="{{subfolder}}/js/less.min.js" type="text/javascript"></script>
         <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.0/jquery.min.js"></script>

--- a/templates/select2_header.twig
+++ b/templates/select2_header.twig
@@ -6,12 +6,10 @@
 
         <link rel="stylesheet/less" href="{{subfolder}}/src/themes/global.less" type="text/css" id="cssmain" />
         <link rel="stylesheet" href="{{subfolder}}/src/themes/{{theme}}/global.css" type="text/css" id="csstheme" />
-
         <link rel="stylesheet" href="{{subfolder}}/js/select2/css/select2.css" type="text/css" />
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.0/jquery-ui.min.css" type="text/css" />
-
-        <link rel="shortcut icon" href="{{subfolder}}/images/themes/{{theme}}/Favicon.ico" type="image/vnd.microsoft.icon" />
-        <link rel="icon" type="image/png" href="{{subfolder}}/images/themes/{{theme}}/Introduction.png" />
+        <link rel="shortcut icon" href="{{Favicon}}" type="image/vnd.microsoft.icon" />
+        <link rel="icon" href="{{Introduction}}" type="image/png" />
 
         <script src="{{subfolder}}/js/less.min.js" type="text/javascript"></script>
         <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.0/jquery.min.js"></script>
@@ -20,11 +18,3 @@
         <script src="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.0/jquery-ui.min.js"></script>
 
         <title data-headertemplate="{{headertemplate}}">{{appName}}</title>
-
-        <script type="text/javascript">
-        $(document).ready(function () {
-            if (window.parent.frames.length > 1) {
-                $('#csstheme', window.parent.frames[0].document).attr('href', '{{subfolder}}/src/themes/{{theme}}/global.css');
-            }
-        });
-        </script>

--- a/templates/sqledit_header.twig
+++ b/templates/sqledit_header.twig
@@ -3,13 +3,15 @@
 
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+
         <link rel="stylesheet" href="{{subfolder}}/src/themes/default/global.css" type="text/css" id="csstheme" />
-        <link rel="shortcut icon" href="{{subfolder}}/images/themes/default/Favicon.ico" type="image/vnd.microsoft.icon" />
-        <link rel="icon" type="image/png" href="{{subfolder}}/images/themes/default/Introduction.png" />
+        <link rel="stylesheet" href="{{subfolder}}/src/themes/{{theme}}/global.css" type="text/css" id="csstheme" />
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.0/jquery-ui.min.css" type="text/css" />
-        <link href="{{subfolder}}/js/codemirror/addon/hint/show-hint.css" rel="stylesheet" />
-        <link href="{{subfolder}}/js/codemirror/codemirror.css" rel="stylesheet" />
-        <link href="{{subfolder}}/js/codemirror/addon/fold/foldgutter.css" rel="stylesheet" />
+        <link rel="stylesheet" href="{{subfolder}}/js/codemirror/addon/hint/show-hint.css" type="text/css" />
+        <link rel="stylesheet" href="{{subfolder}}/js/codemirror/codemirror.css" type="text/css" />
+        <link rel="stylesheet" href="{{subfolder}}/js/codemirror/addon/fold/foldgutter.css" type="text/css" />
+        <link rel="shortcut icon" href="{{Favicon}}" type="image/vnd.microsoft.icon" />
+        <link rel="icon" href="{{Introduction}}" type="image/png" />
 
         <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.0/jquery.min.js"></script>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.0/jquery-ui.min.js"></script>


### PR DESCRIPTION
In reference to  #52

### First issue to consider 

`$container['conf']` is registered as a provider in the Dependency Container (Pimple) and as such it cannot be indirectly modified. Therefore, if we use `$conf['theme']`to store the selected theme, the one specified in the configuration file will always prevail. Even if you have selected another theme, on the next reload that selection won't be taken from $_server_conf, $_COOKIES or $_SESSION, because this need the value of `$conf['theme']`to be overwritten. 

The easiest approach is to inject the `$container['conf']` object to `\PHPPgAdmin\Misc` class which will treat such attribute as a common array, and allow adding and overwriting keys. Convenience methods such as  `\PHPPgAdmin\Misc::setConf` and  `\PHPPgAdmin\Misc::getConf` where added.

The usage of this workaround means also that the `$conf` instance property of other classes, that is currently read from `$container->conf` will have to be taken from `$misc->getConf()` instead.


### Second issue to consider

Given that now the current active theme must be read from the `$misc->getConf()` method, the $container['misc'] providers must have been already registered to be able to set `$container->view->offetSet('theme',$container->misc->getConf('theme'))`. Considering this, the declaration of `$container['misc']` was moved before the declaration of `$container['view']`.

The former means we cannot set the instance property `view` of class `\PHPPgAdmin\Misc` as the value of `$container->view` when calling its constructor (the service isn't defined at that point). For this, a convenience method `\PHPPgAdmin\Misc::setView` was added to be declared once the `view` provider is created. Misc class needs access to the container's view when calling its inner rendering methods. They *should* eventually be moved onto separate classes whose sole purpose would be to render/print HTML.


