### PR TITLE
Feature/add matview tree

### DIFF
--- a/src/controllers/AdminTrait.php
+++ b/src/controllers/AdminTrait.php
@@ -638,14 +638,13 @@ trait AdminTrait
             echo '<p>' . (($defaults['autovacuum'] == 'on') ? $lang['strturnedon'] : $lang['strturnedoff']) . '</p>';
             echo "<p class=\"message\">{$lang['strnotdefaultinred']}</p>";
 
-            function enlight($f, $p)
-            {
+            $enlight = function ($f, $p) {
                 if (isset($f[$p[0]]) and ($f[$p[0]] != $p[1])) {
                     return '<span style="color:#F33;font-weight:bold">' . htmlspecialchars($f[$p[0]]) . '</span>';
                 }
 
                 return htmlspecialchars($p[1]);
-            }
+            };
 
             $columns = [
                 'namespace'                       => [
@@ -662,37 +661,37 @@ trait AdminTrait
                 ],
                 'autovacuum_enabled'              => [
                     'title' => $lang['strenabled'],
-                    'field' => Decorator::callback('enlight', ['autovacuum_enabled', $defaults['autovacuum']]),
+                    'field' => Decorator::callback($enlight, ['autovacuum_enabled', $defaults['autovacuum']]),
                     'type'  => 'verbatim',
                 ],
                 'autovacuum_vacuum_threshold'     => [
                     'title' => $lang['strvacuumbasethreshold'],
-                    'field' => Decorator::callback('enlight', ['autovacuum_vacuum_threshold', $defaults['autovacuum_vacuum_threshold']]),
+                    'field' => Decorator::callback($enlight, ['autovacuum_vacuum_threshold', $defaults['autovacuum_vacuum_threshold']]),
                     'type'  => 'verbatim',
                 ],
                 'autovacuum_vacuum_scale_factor'  => [
                     'title' => $lang['strvacuumscalefactor'],
-                    'field' => Decorator::callback('enlight', ['autovacuum_vacuum_scale_factor', $defaults['autovacuum_vacuum_scale_factor']]),
+                    'field' => Decorator::callback($enlight, ['autovacuum_vacuum_scale_factor', $defaults['autovacuum_vacuum_scale_factor']]),
                     'type'  => 'verbatim',
                 ],
                 'autovacuum_analyze_threshold'    => [
                     'title' => $lang['stranalybasethreshold'],
-                    'field' => Decorator::callback('enlight', ['autovacuum_analyze_threshold', $defaults['autovacuum_analyze_threshold']]),
+                    'field' => Decorator::callback($enlight, ['autovacuum_analyze_threshold', $defaults['autovacuum_analyze_threshold']]),
                     'type'  => 'verbatim',
                 ],
                 'autovacuum_analyze_scale_factor' => [
                     'title' => $lang['stranalyzescalefactor'],
-                    'field' => Decorator::callback('enlight', ['autovacuum_analyze_scale_factor', $defaults['autovacuum_analyze_scale_factor']]),
+                    'field' => Decorator::callback($enlight, ['autovacuum_analyze_scale_factor', $defaults['autovacuum_analyze_scale_factor']]),
                     'type'  => 'verbatim',
                 ],
                 'autovacuum_vacuum_cost_delay'    => [
                     'title' => $lang['strvacuumcostdelay'],
-                    'field' => Decorator::concat(Decorator::callback('enlight', ['autovacuum_vacuum_cost_delay', $defaults['autovacuum_vacuum_cost_delay']]), 'ms'),
+                    'field' => Decorator::concat(Decorator::callback($enlight, ['autovacuum_vacuum_cost_delay', $defaults['autovacuum_vacuum_cost_delay']]), 'ms'),
                     'type'  => 'verbatim',
                 ],
                 'autovacuum_vacuum_cost_limit'    => [
                     'title' => $lang['strvacuumcostlimit'],
-                    'field' => Decorator::callback('enlight', ['autovacuum_vacuum_cost_limit', $defaults['autovacuum_vacuum_cost_limit']]),
+                    'field' => Decorator::callback($enlight, ['autovacuum_vacuum_cost_limit', $defaults['autovacuum_vacuum_cost_limit']]),
                     'type'  => 'verbatim',
                 ],
             ];

--- a/src/controllers/ConversionController.php
+++ b/src/controllers/ConversionController.php
@@ -95,8 +95,7 @@ class ConversionController extends BaseController
 
         $reqvars = $misc->getRequestVars('schema');
 
-        function getIcon($f)
-        {
+        $getIcon = function ($f) {
             switch ($f['contype']) {
                 case 'u':
                     return 'UniqueConstraint';
@@ -107,11 +106,11 @@ class ConversionController extends BaseController
                 case 'p':
                     return 'PrimaryKey';
             }
-        }
+        };
 
         $attrs = [
             'text' => Decorator::field('conname'),
-            'icon' => Decorator::callback('getIcon'),
+            'icon' => Decorator::callback($getIcon),
         ];
 
         return $this->printTree($constraints, $attrs, 'constraints');

--- a/src/controllers/IndexController.php
+++ b/src/controllers/IndexController.php
@@ -219,8 +219,7 @@ class IndexController extends BaseController
 
         $reqvars = $misc->getRequestVars($subject);
 
-        function getIcon($f)
-        {
+        $getIcon = function ($f) {
             if ($f['indisprimary'] == 't') {
                 return 'PrimaryKey';
             }
@@ -230,11 +229,11 @@ class IndexController extends BaseController
             }
 
             return 'Index';
-        }
+        };
 
         $attrs = [
             'text' => Decorator::field('indname'),
-            'icon' => Decorator::callback('getIcon'),
+            'icon' => Decorator::callback($getIcon),
         ];
 
         return $this->printTree($indexes, $attrs, 'indexes');

--- a/src/controllers/MaterializedViewPropertyController.php
+++ b/src/controllers/MaterializedViewPropertyController.php
@@ -293,7 +293,7 @@ class MaterializedViewPropertyController extends BaseController
         $data = $misc->getDatabaseAccessor();
 
         $this->printTrail('view');
-        $this->printTitle($lang['stredit'], 'pg.view.alter');
+        $this->printTitle($lang['stredit'], 'pg.matview.alter');
         $this->printMsg($msg);
 
         $viewdata = $data->getView($_REQUEST['matview']);
@@ -531,7 +531,7 @@ class MaterializedViewPropertyController extends BaseController
         if ($confirm) {
 
             $this->printTrail('view');
-            $this->printTitle($lang['stralter'], 'pg.view.alter');
+            $this->printTitle($lang['stralter'], 'pg.matview.alter');
             $this->printMsg($msg);
 
             // Fetch view info

--- a/src/controllers/TableController.php
+++ b/src/controllers/TableController.php
@@ -359,22 +359,10 @@ class TableController extends BaseController
         $attrs = [
             'text'       => Decorator::field('relname'),
             'icon'       => 'Table',
-            'iconAction' => Decorator::url('display.php',
-                $reqvars,
-                ['table' => Decorator::field('relname')]
-            ),
+            'iconAction' => Decorator::url('display.php', $reqvars, ['table' => Decorator::field('relname')]),
             'toolTip'    => Decorator::field('relcomment'),
-            'action'     => Decorator::redirecturl('redirect.php',
-                $reqvars,
-                ['table' => Decorator::field('relname')]
-            ),
-            'branch'     => Decorator::url('tables.php',
-                $reqvars,
-                [
-                    'action' => 'subtree',
-                    'table'  => Decorator::field('relname'),
-                ]
-            ),
+            'action'     => Decorator::redirecturl('redirect.php', $reqvars, ['table' => Decorator::field('relname')]),
+            'branch'     => Decorator::url('tables.php', $reqvars, ['action' => 'subtree', 'table' => Decorator::field('relname')]),
         ];
 
         return $this->printTree($tables, $attrs, 'tables');

--- a/src/controllers/ViewController.php
+++ b/src/controllers/ViewController.php
@@ -253,12 +253,7 @@ class ViewController extends BaseController
             'iconAction' => Decorator::url('display.php', $reqvars, ['view' => Decorator::field('relname')]),
             'toolTip'    => Decorator::field('relcomment'),
             'action'     => Decorator::redirecturl('redirect.php', $reqvars, ['view' => Decorator::field('relname')]),
-            'branch'     => Decorator::url('views.php', $reqvars,
-                [
-                    'action' => 'subtree',
-                    'view'   => Decorator::field('relname'),
-                ]
-            ),
+            'branch'     => Decorator::url('views.php', $reqvars, ['action' => 'subtree', 'view' => Decorator::field('relname')]),
         ];
 
         return $this->printTree($views, $attrs, 'views');

--- a/src/help/PostgresDoc92.php
+++ b/src/help/PostgresDoc92.php
@@ -1,18 +1,20 @@
 <?php
 
-    namespace PHPPgAdmin\Help;
+namespace PHPPgAdmin\Help;
 
-    /**
-     * Help links for PostgreSQL 9.2 documentation
-     *
-     * $Id: PostgresDoc84.php,v 1.3 2008/11/18 21:35:48 ioguix Exp $
-     */
-    class PostgresDoc92 extends PostgresDoc91
+/**
+ * Help links for PostgreSQL 9.2 documentation
+ *
+ * $Id: PostgresDoc84.php,v 1.3 2008/11/18 21:35:48 ioguix Exp $
+ */
+class PostgresDoc92 extends PostgresDoc91
+{
+
+    public function __construct($conf, $major_version)
     {
+        parent::__construct($conf, $major_version);
 
-        public function __construct($conf, $major_version)
-        {
-            parent::__construct($conf, $major_version);
-        }
-
+        $this->help_page['pg.rule.view'] = 'rules-views.html';
     }
+
+}

--- a/src/help/PostgresDoc93.php
+++ b/src/help/PostgresDoc93.php
@@ -1,18 +1,28 @@
 <?php
 
-    namespace PHPPgAdmin\Help;
+namespace PHPPgAdmin\Help;
 
-    /**
-     * Help links for PostgreSQL 9.3 documentation
-     *
-     * $Id: PostgresDoc84.php,v 1.3 2008/11/18 21:35:48 ioguix Exp $
-     */
-    class PostgresDoc93 extends PostgresDoc92
+/**
+ * Help links for PostgreSQL 9.3 documentation
+ *
+ * $Id: PostgresDoc84.php,v 1.3 2008/11/18 21:35:48 ioguix Exp $
+ */
+class PostgresDoc93 extends PostgresDoc92
+{
+
+    public function __construct($conf, $major_version)
     {
+        parent::__construct($conf, $major_version);
 
-        public function __construct($conf, $major_version)
-        {
-            parent::__construct($conf, $major_version);
-        }
+        $this->help_page['pg.matview'] = 'sql-creatematerializedview.html';
+
+        $this->help_page['pg.matview.create']  = 'sql-creatematerializedview.html';
+        $this->help_page['pg.matview.drop']    = 'sql-dropmaterializedview.html';
+        $this->help_page['pg.matview.alter']   = 'sql-altermaterializedview.html';
+        $this->help_page['pg.matview.refresh'] = 'sql-refreshmaterializedview.html';
+
+        $this->help_page['pg.rule.matview'] = 'rules-materializedviews.html';
 
     }
+
+}

--- a/src/help/PostgresDoc95.php
+++ b/src/help/PostgresDoc95.php
@@ -1,19 +1,18 @@
 <?php
 
-    namespace PHPPgAdmin\Help;
+namespace PHPPgAdmin\Help;
 
-    /**
-     * Help links for PostgreSQL 9.5 documentation
-     *
-     */
-    class PostgresDoc95 extends PostgresDoc94
+/**
+ * Help links for PostgreSQL 9.5 documentation
+ *
+ */
+class PostgresDoc95 extends PostgresDoc94
+{
+
+    public function __construct($conf, $major_version)
     {
-
-        public function __construct($conf, $major_version)
-        {
-            parent::__construct($conf, $major_version);
-
-            $this->help_page['pg.matview'] = 'sql-creatematerializedview.html';
-        }
+        parent::__construct($conf, $major_version);
 
     }
+
+}


### PR DESCRIPTION
- Adds help entries to create, alter, drop and refresh materialized views
- These entries where moved from PG 9.5 to PG 9.3 (the earliest version with support for matviews)
- Usage of Decorator::callback will always receive a closure instead of a string, since those global scoped functions will no longer exist.