### PR TITLE
remove parent::__construct

### DIFF
--- a/index.php
+++ b/index.php
@@ -73,7 +73,7 @@ $app->post('/redirect[/{subject}]', function ($request, $response, $args) use ($
 
                 $this->misc->setNoDBConnection(true);
 
-                $controller = new \PHPPgAdmin\Controller\LoginController($this);
+                $controller = new \PHPPgAdmin\Controller\LoginController($this, true);
                 $body_html  = $controller->doLoginForm($msg);
                 $body->write($body_html);
             }
@@ -107,7 +107,7 @@ $app->get('/redirect[/{subject}]', function ($request, $response, $args) use ($m
 
             $this->misc->setNoDBConnection(true);
 
-            $controller = new \PHPPgAdmin\Controller\LoginController($this);
+            $controller = new \PHPPgAdmin\Controller\LoginController($this, true);
             $body_html  = $controller->doLoginForm($msg);
             $body->write($body_html);
         }

--- a/src/controllers/BaseController.php
+++ b/src/controllers/BaseController.php
@@ -33,8 +33,12 @@ class BaseController
     protected $header_controller = null;
     public $msg                  = '';
 
-    /* Constructor */
-    public function __construct(\Slim\Container $container)
+    /**
+     * Constructs the base controller (common for almost all controllers)
+     * @param \Slim\Container $container        the $app container
+     * @param boolean         $no_db_connection [optional] if true, sets  $this->misc->setNoDBConnection(true);
+     */
+    public function __construct(\Slim\Container $container, $no_db_connection = false)
     {
         $this->container = $container;
         $this->lang      = $container->get('lang');
@@ -56,6 +60,11 @@ class BaseController
         $this->phpMinVer        = $container->get('settings')['phpMinVer'];
 
         $msg = $container->get('msg');
+
+        if ($no_db_connection === true) {
+            $this->misc->setNoDBConnection(true);
+        }
+
         if ($this->misc->getNoDBConnection() === false) {
             if ($this->misc->getServerId() === null) {
                 echo $this->lang['strnoserversupplied'];

--- a/src/controllers/BrowserController.php
+++ b/src/controllers/BrowserController.php
@@ -9,21 +9,13 @@ class BrowserController extends BaseController
 {
     public $_name = 'BrowserController';
 
-    /* Constructor */
-    public function __construct(\Slim\Container $container)
-    {
-        $this->misc = $container->get('misc');
-
-        $this->misc->setNoDBConnection(true);
-
-        parent::__construct($container);
-    }
-
     public function render()
     {
         $conf = $this->conf;
         $misc = $this->misc;
         $lang = $this->lang;
+
+        $misc->setNoDBConnection(true);
 
         $this->setNoBottomLink(true);
 

--- a/src/controllers/DBExportController.php
+++ b/src/controllers/DBExportController.php
@@ -9,15 +9,6 @@ class DBExportController extends BaseController
 {
     public $_name = 'DBExportController';
 
-    /* Constructor */
-    public function __construct(\Slim\Container $container)
-    {
-        parent::__construct($container);
-
-        // Prevent timeouts on large exports
-        set_time_limit(0);
-    }
-
     public function render()
     {
         $conf   = $this->conf;
@@ -25,6 +16,9 @@ class DBExportController extends BaseController
         $lang   = $this->lang;
         $data   = $misc->getDatabaseAccessor();
         $action = $this->action;
+
+        // Prevent timeouts on large exports
+        set_time_limit(0);
 
         // Include application functions
         $f_schema = $f_object = '';

--- a/src/controllers/DataExportController.php
+++ b/src/controllers/DataExportController.php
@@ -17,15 +17,6 @@ class DataExportController extends BaseController
         'xml'  => 'xml',
     ];
 
-    /* Constructor */
-    public function __construct(\Slim\Container $container)
-    {
-        parent::__construct($container);
-
-        set_time_limit(0);
-
-    }
-
     public function render()
     {
 
@@ -34,6 +25,8 @@ class DataExportController extends BaseController
         $lang   = $this->lang;
         $data   = $misc->getDatabaseAccessor();
         $action = $this->action;
+
+        set_time_limit(0);
 
         // if (!isset($_REQUEST['table']) && !isset($_REQUEST['query']))
         // What must we do in this case? Maybe redirect to the homepage?

--- a/src/controllers/DataImportController.php
+++ b/src/controllers/DataImportController.php
@@ -9,21 +9,15 @@ class DataImportController extends BaseController
 {
     public $_name = 'DataImportController';
 
-    /* Constructor */
-    public function __construct(\Slim\Container $container)
-    {
-        parent::__construct($container);
-
-        // Prevent timeouts on large exports
-        set_time_limit(0);
-    }
-
     public function render()
     {
         $misc   = $this->misc;
         $lang   = $this->lang;
         $action = $this->action;
         $data   = $misc->getDatabaseAccessor();
+
+        // Prevent timeouts on large exports
+        set_time_limit(0);
 
         $this->printHeader($lang['strimport']);
         $this->printTrail('table');

--- a/src/controllers/DisplayController.php
+++ b/src/controllers/DisplayController.php
@@ -9,17 +9,6 @@ class DisplayController extends BaseController
 {
     public $_name = 'DisplayController';
 
-    /* Constructor */
-    public function __construct(\Slim\Container $container)
-    {
-        parent::__construct($container);
-
-        // Prevent timeouts on large exports (non-safe mode only)
-        if (!ini_get('safe_mode')) {
-            set_time_limit(0);
-        }
-    }
-
     public function render()
     {
         $conf           = $this->conf;
@@ -33,6 +22,8 @@ class DisplayController extends BaseController
         if ($action == 'dobrowsefk') {
             $this->doBrowseFK();
         }
+
+        set_time_limit(0);
 
         $scripts = '<script src="' . SUBFOLDER . '/js/display.js" type="text/javascript"></script>';
 

--- a/src/controllers/IntroController.php
+++ b/src/controllers/IntroController.php
@@ -9,14 +9,6 @@ class IntroController extends BaseController
 {
     public $_name = 'IntroController';
 
-    /* Constructor */
-    public function __construct(\Slim\Container $container)
-    {
-        $this->misc = $container->get('misc');
-        $this->misc->setNoDBConnection(true);
-        parent::__construct($container);
-    }
-
     public function render()
     {
 

--- a/src/controllers/LoginController.php
+++ b/src/controllers/LoginController.php
@@ -27,14 +27,6 @@ class LoginController extends BaseController
 
     /* Constructor */
 
-    public function __construct(\Slim\Container $container)
-    {
-        $this->misc = $container->get('misc');
-
-        $this->misc->setNoDBConnection(true);
-        parent::__construct($container);
-    }
-
     public function render()
     {
         $misc   = $this->misc;

--- a/src/controllers/SQLQueryController.php
+++ b/src/controllers/SQLQueryController.php
@@ -13,15 +13,14 @@ class SQLQueryController extends BaseController
     public $start_time = null;
     public $duration   = null;
 
-    /* Constructor */
-    public function __construct(\Slim\Container $container)
+    public function render()
     {
-        parent::__construct($container);
+        $conf = $this->conf;
+        $lang = $this->lang;
+        $misc = $this->misc;
+        $data = $misc->getDatabaseAccessor();
 
-        // Prevent timeouts on large exports (non-safe mode only)
-        if (!ini_get('safe_mode')) {
-            set_time_limit(0);
-        }
+        set_time_limit(0);
 
         // We need to store the query in a session for editing purposes
         // We avoid GPC vars to avoid truncating long queries
@@ -48,15 +47,6 @@ class SQLQueryController extends BaseController
         if (isset($_REQUEST['subject'])) {
             $this->subject = $_REQUEST['subject'];
         }
-
-    }
-
-    public function render()
-    {
-        $conf = $this->conf;
-        $lang = $this->lang;
-        $misc = $this->misc;
-        $data = $misc->getDatabaseAccessor();
 
         // Check to see if pagination has been specified. In that case, send to display
         // script for pagination

--- a/src/controllers/ServerController.php
+++ b/src/controllers/ServerController.php
@@ -17,16 +17,6 @@ class ServerController extends BaseController
     public $start_time  = null;
     public $duration    = null;
 
-    /* Constructor */
-    public function __construct(\Slim\Container $container)
-    {
-        $this->misc = $container->get('misc');
-
-        $this->misc->setNoDBConnection(true);
-
-        parent::__construct($container);
-    }
-
     public function render()
     {
         $conf = $this->conf;

--- a/src/decorators/RedirectUrlDecorator.php
+++ b/src/decorators/RedirectUrlDecorator.php
@@ -23,7 +23,7 @@ class RedirectUrlDecorator extends Decorator
             return '';
         }
 
-        $this->prtrace('url', $url);
+        //$this->prtrace('url', $url);
 
         if (!empty($this->q)) {
             $queryVars = Decorator::get_sanitized_value($this->q, $fields);

--- a/src/views/browser.php
+++ b/src/views/browser.php
@@ -1,9 +1,9 @@
 <?php
 
-    if (!defined('BASE_PATH')) {
-        require_once '../lib.inc.php';
-    }
+if (!defined('BASE_PATH')) {
+    require_once '../lib.inc.php';
+}
 
-    $browser_controller = new \PHPPgAdmin\Controller\BrowserController($container);
+$browser_controller = new \PHPPgAdmin\Controller\BrowserController($container, true);
 
-    $browser_controller->render();
+$browser_controller->render();

--- a/src/views/intro.php
+++ b/src/views/intro.php
@@ -4,6 +4,6 @@ if (!defined('BASE_PATH')) {
     require_once '../lib.inc.php';
 }
 
-$intro_controller = new \PHPPgAdmin\Controller\IntroController($container);
+$intro_controller = new \PHPPgAdmin\Controller\IntroController($container, true);
 
 $intro_controller->render();

--- a/src/views/login.php
+++ b/src/views/login.php
@@ -1,15 +1,15 @@
 <?php
 
-    /**
-     * Login screen
-     *
-     * $Id: login.php,v 1.38 2007/09/04 19:39:48 ioguix Exp $
-     */
-    if (!defined('BASE_PATH')) {
+/**
+ * Login screen
+ *
+ * $Id: login.php,v 1.38 2007/09/04 19:39:48 ioguix Exp $
+ */
+if (!defined('BASE_PATH')) {
 
-        require_once '../lib.inc.php';
-    }
+    require_once '../lib.inc.php';
+}
 
-    $login_controller = new \PHPPgAdmin\Controller\LoginController($container);
+$login_controller = new \PHPPgAdmin\Controller\LoginController($container, true);
 
-    $login_controller->render();
+$login_controller->render();

--- a/src/views/servers.php
+++ b/src/views/servers.php
@@ -1,13 +1,13 @@
 <?php
 
-    /**
-     * Manage servers
-     *
-     * $Id: servers.php,v 1.12 2008/02/18 22:20:26 ioguix Exp $
-     */
+/**
+ * Manage servers
+ *
+ * $Id: servers.php,v 1.12 2008/02/18 22:20:26 ioguix Exp $
+ */
 
-    require_once '../lib.inc.php';
+require_once '../lib.inc.php';
 
-    $server_controller = new \PHPPgAdmin\Controller\ServerController($container);
+$server_controller = new \PHPPgAdmin\Controller\ServerController($container, true);
 
-    $server_controller->render();
+$server_controller->render();


### PR DESCRIPTION
Every controller is now able to rely on `BaseController::__construct`.

Previously, some controllers needed to set time limit to 0. (This is now handled in the render method).

Other controllers needed to set `$misc->setNoDBConnection(true)` to avoid the "no server supplied" error.

This is now achieved by modifying the `BaseController` constructor in order to accept a second parameter, `boolean` `$no_db_connection` which calls `$misc->setNoDBConnection(true)` when `true`.

In the corresponding view for BrowserController, LoginController and IntroController, the controller is instanced with said parameter set to true.


